### PR TITLE
FMWK-530 Fix handlers .Wait() context

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// use backupHandler.Wait() to wait for the job to finish or fail
-	err = backupHandler.Wait(ctx)
+	err = backupHandler.Wait()
 	if err != nil {
 		log.Printf("Backup failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	// use restoreHandler.Wait() to wait for the job to finish or fail
-	err = restoreHandler.Wait(ctx)
+	err = restoreHandler.Wait()
 	if err != nil {
 		log.Printf("Restore failed: %v", err)
 	}

--- a/client.go
+++ b/client.go
@@ -167,7 +167,7 @@ func (c *Client) Backup(
 		return nil, err
 	}
 
-	handler := newBackupHandler(config, c.aerospikeClient, c.logger, writer)
+	handler := newBackupHandler(ctx, config, c.aerospikeClient, c.logger, writer)
 	handler.run(ctx)
 
 	return handler, nil
@@ -198,7 +198,7 @@ func (c *Client) Restore(
 		return nil, err
 	}
 
-	handler := newRestoreHandler(config, c.aerospikeClient, c.logger, streamingReader)
+	handler := newRestoreHandler(ctx, config, c.aerospikeClient, c.logger, streamingReader)
 	handler.startAsync(ctx)
 
 	return handler, nil

--- a/examples/aws/s3/main.go
+++ b/examples/aws/s3/main.go
@@ -95,7 +95,7 @@ func runBackup(ctx context.Context, c *backup.Client) {
 	}
 
 	// use backupHandler.Wait() to wait for the job to finish or fail
-	err = backupHandler.Wait(ctx)
+	err = backupHandler.Wait()
 	if err != nil {
 		log.Printf("Backup failed: %v", err)
 	}
@@ -137,7 +137,7 @@ func runRestore(ctx context.Context, c *backup.Client) {
 	}
 
 	// use restoreHandler.Wait() to wait for the job to finish or fail
-	err = restoreHandler.Wait(ctx)
+	err = restoreHandler.Wait()
 	if err != nil {
 		log.Printf("Restore failed: %v", err)
 	}

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	// use backupHandler.Wait() to wait for the job to finish or fail
-	err = backupHandler.Wait(ctx)
+	err = backupHandler.Wait()
 	if err != nil {
 		log.Printf("Backup failed: %v", err)
 	}
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	// use restoreHandler.Wait() to wait for the job to finish or fail
-	err = restoreHandler.Wait(ctx)
+	err = restoreHandler.Wait()
 	if err != nil {
 		log.Printf("Restore failed: %v", err)
 	}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -239,7 +239,7 @@ func runBackupRestore(suite *backupRestoreTestSuite, backupConfig *backup.Backup
 	suite.Nil(err)
 	suite.NotNil(bh)
 
-	err = bh.Wait(ctx)
+	err = bh.Wait()
 	suite.Nil(err)
 
 	err = suite.testClient.Truncate(suite.namespace, suite.set)
@@ -255,7 +255,7 @@ func runBackupRestore(suite *backupRestoreTestSuite, backupConfig *backup.Backup
 	suite.Nil(err)
 	suite.NotNil(rh)
 
-	err = rh.Wait(ctx)
+	err = rh.Wait()
 	suite.Nil(err)
 
 	suite.testClient.ValidateRecords(suite.T(), expectedRecs, suite.namespace, suite.set)
@@ -382,7 +382,7 @@ func runBackupRestoreDirectory(suite *backupRestoreTestSuite,
 	statsBackup := bh.GetStats()
 	suite.NotNil(statsBackup)
 
-	err = bh.Wait(ctx)
+	err = bh.Wait()
 	suite.Nil(err)
 
 	suite.Require().Equal(uint64(len(expectedRecs)), statsBackup.GetReadRecords())
@@ -411,7 +411,7 @@ func runBackupRestoreDirectory(suite *backupRestoreTestSuite,
 	statsRestore := rh.GetStats()
 	suite.NotNil(statsRestore)
 
-	err = rh.Wait(ctx)
+	err = rh.Wait()
 	suite.Nil(err)
 
 	suite.Require().Equal(uint64(len(expectedRecs)), statsRestore.GetReadRecords())
@@ -476,7 +476,7 @@ func (suite *backupRestoreTestSuite) TestRestoreExpiredRecords() {
 	restoreStats := rh.GetStats()
 	suite.NotNil(restoreStats)
 
-	err = rh.Wait(ctx)
+	err = rh.Wait()
 	suite.Nil(err)
 
 	statsRestore := rh.GetStats()
@@ -540,7 +540,7 @@ func (suite *backupRestoreTestSuite) TestBackupRestoreIOWithPartitions() {
 	suite.Nil(err)
 	suite.NotNil(bh)
 
-	err = bh.Wait(ctx)
+	err = bh.Wait()
 	suite.Nil(err)
 
 	err = suite.testClient.Truncate(suite.namespace, suite.set)
@@ -559,7 +559,7 @@ func (suite *backupRestoreTestSuite) TestBackupRestoreIOWithPartitions() {
 	suite.Nil(err)
 	suite.NotNil(rh)
 
-	err = rh.Wait(ctx)
+	err = rh.Wait()
 	suite.Nil(err)
 
 	suite.testClient.ValidateRecords(suite.T(), expectedRecs, suite.namespace, suite.set)
@@ -578,8 +578,7 @@ func (suite *backupRestoreTestSuite) TestBackupContext() {
 	suite.NotNil(bh)
 	suite.Nil(err)
 
-	ctx = context.Background()
-	err = bh.Wait(ctx)
+	err = bh.Wait()
 	suite.NotNil(err)
 }
 
@@ -597,8 +596,7 @@ func (suite *backupRestoreTestSuite) TestRestoreContext() {
 	suite.NotNil(rh)
 	suite.Nil(err)
 
-	ctx = context.Background()
-	err = rh.Wait(ctx)
+	err = rh.Wait()
 	suite.NotNil(err)
 }
 


### PR DESCRIPTION
- removed context from handlers .Wait() methods
- pass global backup context to handlers