### PR TITLE
FMWK-531 Revise handler's context 

### DIFF
--- a/client.go
+++ b/client.go
@@ -158,7 +158,10 @@ func NewClient(ac AerospikeClient, opts ...ClientOpt) (*Client, error) {
 
 func (c *Client) getUsableInfoPolicy(p *a.InfoPolicy) *a.InfoPolicy {
 	if p == nil {
-		p = c.aerospikeClient.GetDefaultInfoPolicy()
+		dp := c.aerospikeClient.GetDefaultInfoPolicy()
+		cp := *dp
+
+		return &cp
 	}
 
 	return p
@@ -166,7 +169,10 @@ func (c *Client) getUsableInfoPolicy(p *a.InfoPolicy) *a.InfoPolicy {
 
 func (c *Client) getUsableWritePolicy(p *a.WritePolicy) *a.WritePolicy {
 	if p == nil {
-		p = c.aerospikeClient.GetDefaultWritePolicy()
+		dp := c.aerospikeClient.GetDefaultWritePolicy()
+		cp := *dp
+
+		return &cp
 	}
 
 	return p
@@ -174,7 +180,10 @@ func (c *Client) getUsableWritePolicy(p *a.WritePolicy) *a.WritePolicy {
 
 func (c *Client) getUsableScanPolicy(p *a.ScanPolicy) *a.ScanPolicy {
 	if p == nil {
-		p = c.aerospikeClient.GetDefaultScanPolicy()
+		dp := c.aerospikeClient.GetDefaultScanPolicy()
+		cp := *dp
+
+		return &cp
 	}
 
 	return p

--- a/client.go
+++ b/client.go
@@ -181,7 +181,7 @@ func (c *Client) getUsableScanPolicy(p *a.ScanPolicy) *a.ScanPolicy {
 }
 
 // Backup starts a backup operation that writes data to a provided writer.
-//   - ctx can be used to ctxCancel the backup operation.
+//   - ctx can be used to cancel the backup operation.
 //   - config is the configuration for the backup operation.
 //   - writer creates new writers for the backup operation.
 func (c *Client) Backup(
@@ -209,7 +209,7 @@ func (c *Client) Backup(
 
 // Restore starts a restore operation that reads data from given readers.
 // The backup data may be in a single file or multiple files.
-//   - ctx can be used to ctxCancel the restore operation.
+//   - ctx can be used to cancel the restore operation.
 //   - config is the configuration for the restore operation.
 //   - streamingReader provides readers with access to backup data.
 func (c *Client) Restore(

--- a/examples/aws/s3/main.go
+++ b/examples/aws/s3/main.go
@@ -93,8 +93,10 @@ func runBackup(ctx context.Context, c *backup.Client) {
 		panic(err)
 	}
 
-	// use backupHandler.Wait() to wait for the job to finish or fail
-	err = backupHandler.Wait()
+	// Use backupHandler.Wait(ctx) to wait for the job to finish or fail.
+	// You can use different context here, and if it is canceled
+	// backupClient.Backup(ctx, backupCfg, writers) context will be cancelled too.
+	err = backupHandler.Wait(ctx)
 	if err != nil {
 		log.Printf("Backup failed: %v", err)
 	}
@@ -135,8 +137,10 @@ func runRestore(ctx context.Context, c *backup.Client) {
 		panic(err)
 	}
 
-	// use restoreHandler.Wait() to wait for the job to finish or fail
-	err = restoreHandler.Wait()
+	// Use restoreHandler.Wait(ctx) to wait for the job to finish or fail.
+	// You can use different context here, and if it is canceled
+	// backupClient.Restore(ctx, restoreCfg, streamingReader) context will be cancelled too.
+	err = restoreHandler.Wait(ctx)
 	if err != nil {
 		log.Printf("Restore failed: %v", err)
 	}

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -48,8 +48,10 @@ func main() {
 		panic(err)
 	}
 
-	// use backupHandler.Wait() to wait for the job to finish or fail
-	err = backupHandler.Wait()
+	// Use backupHandler.Wait(ctx) to wait for the job to finish or fail.
+	// You can use different context here, and if it is canceled
+	// backupClient.Backup(ctx, backupCfg, writers) context will be cancelled too.
+	err = backupHandler.Wait(ctx)
 	if err != nil {
 		log.Printf("Backup failed: %v", err)
 	}
@@ -67,8 +69,10 @@ func main() {
 		panic(err)
 	}
 
-	// use restoreHandler.Wait() to wait for the job to finish or fail
-	err = restoreHandler.Wait()
+	// Use restoreHandler.Wait(ctx) to wait for the job to finish or fail.
+	// You can use different context here, and if it is canceled
+	// backupClient.Restore(ctx, restoreCfg, streamingReader) context will be cancelled too.
+	err = restoreHandler.Wait(ctx)
 	if err != nil {
 		log.Printf("Restore failed: %v", err)
 	}

--- a/handler_backup.go
+++ b/handler_backup.go
@@ -50,8 +50,8 @@ type Writer interface {
 // BackupHandler handles a backup job.
 type BackupHandler struct {
 	// Global backup context for a whole backup process.
-	ctx       context.Context
-	ctxCancel context.CancelFunc
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	writer          Writer
 	encoder         Encoder
@@ -83,11 +83,11 @@ func newBackupHandler(
 	limiter := makeBandwidthLimiter(config.Bandwidth)
 
 	// redefine context cancel.
-	ctx, ctxCancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 
 	return &BackupHandler{
 		ctx:                    ctx,
-		ctxCancel:              ctxCancel,
+		cancel:                 cancel,
 		config:                 config,
 		aerospikeClient:        ac,
 		id:                     id,
@@ -307,7 +307,7 @@ func (bh *BackupHandler) Wait(ctx context.Context) error {
 		return bh.ctx.Err()
 	case <-ctx.Done():
 		// Process local context.
-		bh.ctxCancel()
+		bh.cancel()
 		return ctx.Err()
 	case err := <-bh.errors:
 		return err

--- a/handler_backup.go
+++ b/handler_backup.go
@@ -50,19 +50,23 @@ type Writer interface {
 // BackupHandler handles a backup job.
 type BackupHandler struct {
 	// Global backup context for a whole backup process.
-	ctx                    context.Context
-	writer                 Writer
-	encoder                Encoder
-	config                 *BackupConfig
-	aerospikeClient        AerospikeClient
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
+	writer          Writer
+	encoder         Encoder
+	config          *BackupConfig
+	aerospikeClient AerospikeClient
+
 	logger                 *slog.Logger
 	firstFileHeaderWritten *atomic.Bool
 	limiter                *rate.Limiter
-	errors                 chan error
 	infoClient             *asinfo.InfoClient
 	scanLimiter            *semaphore.Weighted
+	errors                 chan error
 	id                     string
-	stats                  models.BackupStats
+
+	stats models.BackupStats
 }
 
 // newBackupHandler creates a new BackupHandler.
@@ -78,8 +82,12 @@ func newBackupHandler(
 	logger = logging.WithHandler(logger, id, logging.HandlerTypeBackup, writer.GetType())
 	limiter := makeBandwidthLimiter(config.Bandwidth)
 
+	// redefine context cancel.
+	ctx, ctxCancel := context.WithCancel(ctx)
+
 	return &BackupHandler{
 		ctx:                    ctx,
+		ctxCancel:              ctxCancel,
 		config:                 config,
 		aerospikeClient:        ac,
 		id:                     id,
@@ -95,12 +103,12 @@ func newBackupHandler(
 
 // run runs the backup job.
 // currently this should only be run once.
-func (bh *BackupHandler) run(ctx context.Context) {
+func (bh *BackupHandler) run() {
 	bh.errors = make(chan error, 1)
 	bh.stats.Start()
 
 	go doWork(bh.errors, bh.logger, func() error {
-		return bh.backupSync(ctx)
+		return bh.backupSync(bh.ctx)
 	})
 }
 
@@ -288,14 +296,19 @@ func (bh *BackupHandler) GetStats() *models.BackupStats {
 }
 
 // Wait waits for the backup job to complete and returns an error if the job failed.
-func (bh *BackupHandler) Wait() error {
+func (bh *BackupHandler) Wait(ctx context.Context) error {
 	defer func() {
 		bh.stats.Stop()
 	}()
 
 	select {
 	case <-bh.ctx.Done():
+		// Wait for global context.
 		return bh.ctx.Err()
+	case <-ctx.Done():
+		// Process local context.
+		bh.ctxCancel()
+		return ctx.Err()
 	case err := <-bh.errors:
 		return err
 	}

--- a/handler_restore.go
+++ b/handler_restore.go
@@ -46,15 +46,19 @@ type StreamingReader interface {
 // RestoreHandler handles a restore job using the given reader.
 type RestoreHandler struct {
 	// Global backup context for a whole restore process.
-	ctx             context.Context
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
 	reader          StreamingReader
 	config          *RestoreConfig
 	aerospikeClient AerospikeClient
-	logger          *slog.Logger
-	limiter         *rate.Limiter
-	errors          chan error
-	id              string
-	stats           models.RestoreStats
+
+	logger  *slog.Logger
+	limiter *rate.Limiter
+	errors  chan error
+	id      string
+
+	stats models.RestoreStats
 }
 
 // newRestoreHandler creates a new RestoreHandler.
@@ -67,9 +71,12 @@ func newRestoreHandler(
 ) *RestoreHandler {
 	id := uuid.NewString()
 	logger = logging.WithHandler(logger, id, logging.HandlerTypeRestore, reader.GetType())
+	// redefine context cancel.
+	ctx, ctxCancel := context.WithCancel(ctx)
 
 	return &RestoreHandler{
 		ctx:             ctx,
+		ctxCancel:       ctxCancel,
 		config:          config,
 		aerospikeClient: ac,
 		id:              id,
@@ -79,12 +86,12 @@ func newRestoreHandler(
 	}
 }
 
-func (rh *RestoreHandler) startAsync(ctx context.Context) {
+func (rh *RestoreHandler) startAsync() {
 	rh.errors = make(chan error, 1)
 	rh.stats.Start()
 
 	go doWork(rh.errors, rh.logger, func() error {
-		return rh.restore(ctx)
+		return rh.restore(rh.ctx)
 	})
 }
 
@@ -256,14 +263,19 @@ func (rh *RestoreHandler) GetStats() *models.RestoreStats {
 }
 
 // Wait waits for the restore job to complete and returns an error if the job failed.
-func (rh *RestoreHandler) Wait() error {
+func (rh *RestoreHandler) Wait(ctx context.Context) error {
 	defer func() {
 		rh.stats.Stop()
 	}()
 
 	select {
 	case <-rh.ctx.Done():
+		// Wait for global context.
 		return rh.ctx.Err()
+	case <-ctx.Done():
+		// Process local context.
+		rh.ctxCancel()
+		return ctx.Err()
 	case err := <-rh.errors:
 		return err
 	}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -239,7 +239,7 @@ func runBackupRestore(suite *backupRestoreTestSuite, backupConfig *backup.Backup
 	suite.Nil(err)
 	suite.NotNil(bh)
 
-	err = bh.Wait()
+	err = bh.Wait(ctx)
 	suite.Nil(err)
 
 	err = suite.testClient.Truncate(suite.namespace, suite.set)
@@ -255,7 +255,7 @@ func runBackupRestore(suite *backupRestoreTestSuite, backupConfig *backup.Backup
 	suite.Nil(err)
 	suite.NotNil(rh)
 
-	err = rh.Wait()
+	err = rh.Wait(ctx)
 	suite.Nil(err)
 
 	suite.testClient.ValidateRecords(suite.T(), expectedRecs, suite.namespace, suite.set)
@@ -382,7 +382,7 @@ func runBackupRestoreDirectory(suite *backupRestoreTestSuite,
 	statsBackup := bh.GetStats()
 	suite.NotNil(statsBackup)
 
-	err = bh.Wait()
+	err = bh.Wait(ctx)
 	suite.Nil(err)
 
 	suite.Require().Equal(uint64(len(expectedRecs)), statsBackup.GetReadRecords())
@@ -411,7 +411,7 @@ func runBackupRestoreDirectory(suite *backupRestoreTestSuite,
 	statsRestore := rh.GetStats()
 	suite.NotNil(statsRestore)
 
-	err = rh.Wait()
+	err = rh.Wait(ctx)
 	suite.Nil(err)
 
 	suite.Require().Equal(uint64(len(expectedRecs)), statsRestore.GetReadRecords())
@@ -476,7 +476,7 @@ func (suite *backupRestoreTestSuite) TestRestoreExpiredRecords() {
 	restoreStats := rh.GetStats()
 	suite.NotNil(restoreStats)
 
-	err = rh.Wait()
+	err = rh.Wait(ctx)
 	suite.Nil(err)
 
 	statsRestore := rh.GetStats()
@@ -540,7 +540,7 @@ func (suite *backupRestoreTestSuite) TestBackupRestoreIOWithPartitions() {
 	suite.Nil(err)
 	suite.NotNil(bh)
 
-	err = bh.Wait()
+	err = bh.Wait(ctx)
 	suite.Nil(err)
 
 	err = suite.testClient.Truncate(suite.namespace, suite.set)
@@ -559,7 +559,7 @@ func (suite *backupRestoreTestSuite) TestBackupRestoreIOWithPartitions() {
 	suite.Nil(err)
 	suite.NotNil(rh)
 
-	err = rh.Wait()
+	err = rh.Wait(ctx)
 	suite.Nil(err)
 
 	suite.testClient.ValidateRecords(suite.T(), expectedRecs, suite.namespace, suite.set)
@@ -578,7 +578,7 @@ func (suite *backupRestoreTestSuite) TestBackupContext() {
 	suite.NotNil(bh)
 	suite.Nil(err)
 
-	err = bh.Wait()
+	err = bh.Wait(ctx)
 	suite.NotNil(err)
 }
 
@@ -596,7 +596,7 @@ func (suite *backupRestoreTestSuite) TestRestoreContext() {
 	suite.NotNil(rh)
 	suite.Nil(err)
 
-	err = rh.Wait()
+	err = rh.Wait(ctx)
 	suite.NotNil(err)
 }
 


### PR DESCRIPTION
- removed unnecessary context  from handler.run()
- added cancel function to global handler contrext
- added new context to handler.run.Wait(ctx), so if we interrupt .Wait() func we will cancel global context and stop backup