### PR TITLE
FMWK-519 Add secret agent support for cloud configs in CLI tools

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,6 +61,8 @@ run:
 
 # Test exclusion examples
 issues:
+  exclude-dirs:
+    - main
   exclude-rules:
     - text: 'shadow: declaration of "(err|ctx)" shadows declaration at' # Allow idiomatic shadowing of err and ctx
       linters: 

--- a/cmd/asbackup/main.go
+++ b/cmd/asbackup/main.go
@@ -113,7 +113,11 @@ func init() {
 		encryptionFlagSet.PrintDefaults()
 
 		// Print section: Secret Agent Flags
-		fmt.Println("\nSecret Agent Flags:")
+		fmt.Println("\nSecret Agent Flags:\n" +
+			"Options pertaining to the Aerospike secret agent https://docs.aerospike.com/tools/secret-agent.\n" +
+			"Both asbackup and asrestore support getting all the cloud config parameters from the Aerospike secret agent.\n" +
+			"To use a secret as an option, use this format 'secrets:<resource_name>:<secret_name>' \n" +
+			"Example: asbackup --azure-account-name secret:resource1:azaccount")
 		secretAgentFlagSet.PrintDefaults()
 
 		// Print section: AWS Flags

--- a/cmd/asbackup/readme.md
+++ b/cmd/asbackup/readme.md
@@ -155,6 +155,10 @@ Encryption Flags:
       --encryption-key-secret string   Grabs the encryption key from secret-agent.
 
 Secret Agent Flags:
+Options pertaining to the Aerospike secret agent https://docs.aerospike.com/tools/secret-agent.
+Both asbackup and asrestore support getting all the cloud config parameters from the Aerospike secret agent.
+To use a secret as an option, use this format 'secrets:<resource_name>:<secret_name>' 
+Example: asbackup --azure-account-name secret:resource1:azaccount
       --sa-connection-type string   Secret agent connection type, supported types: tcp, unix. (default "tcp")
       --sa-address string           Secret agent host for TCP connection or socket file path for UDS connection.
       --sa-port int                 Secret agent port (only for TCP connection).

--- a/cmd/asrestore/main.go
+++ b/cmd/asrestore/main.go
@@ -113,7 +113,11 @@ func init() {
 		encryptionFlagSet.PrintDefaults()
 
 		// Print section: Secret Agent Flags
-		fmt.Println("\nSecret Agent Flags:")
+		fmt.Println("\nSecret Agent Flags:\n" +
+			"Options pertaining to the Aerospike secret agent https://docs.aerospike.com/tools/secret-agent.\n" +
+			"Both asbackup and asrestore support getting all the cloud config parameters from the Aerospike secret agent.\n" +
+			"To use a secret as an option, use this format 'secrets:<resource_name>:<secret_name>' \n" +
+			"Example: asrestore --azure-account-name secret:resource1:azaccount")
 		secretAgentFlagSet.PrintDefaults()
 
 		// Print section: AWS Flags

--- a/cmd/asrestore/readme.md
+++ b/cmd/asrestore/readme.md
@@ -50,12 +50,12 @@ Aerospike Client Flags:
 Restore Flags:
   -d, --directory string         The Directory that holds the backup files. Required, unless -o or -e is used.
   -n, --namespace string         The namespace to be backed up. Required.
-  -s, --set stringArray          The set(s) to be backed up.
+  -s, --set string               The set(s) to be backed up.
                                  If multiple sets are being backed up, filter-exp cannot be used.
                                  if empty all sets.
   -L, --records-per-second int   Limit total returned records per second (rps).
                                  Do not apply rps limit if records-per-second is zero.
-  -B, --bin-list stringArray     Only include the given bins in the backup.
+  -B, --bin-list string          Only include the given bins in the backup.
                                  If empty include all bins.
   -w, --parallel int             Maximum number of scan calls to run in parallel.
                                  If only one partition range is given, or the entire namespace is being backed up, the range
@@ -120,6 +120,10 @@ Encryption Flags:
       --encryption-key-secret string   Grabs the encryption key from secret-agent.
 
 Secret Agent Flags:
+Options pertaining to the Aerospike secret agent https://docs.aerospike.com/tools/secret-agent.
+Both asbackup and asrestore support getting all the cloud config parameters from the Aerospike secret agent.
+To use a secret as an option, use this format 'secrets:<resource_name>:<secret_name>' 
+Example: asrestore --azure-account-name secret:resource1:azaccount
       --sa-connection-type string   Secret agent connection type, supported types: tcp, unix. (default "tcp")
       --sa-address string           Secret agent host for TCP connection or socket file path for UDS connection.
       --sa-port int                 Secret agent port (only for TCP connection).
@@ -129,19 +133,19 @@ Secret Agent Flags:
 
 AWS Flags:
       --s3-region string              The S3 region that the bucket(s) exist in.
-      --s3-profile string             The S3 profile to use for credentials. (default "default")
+      --s3-profile string             The S3 profile to use for credentials.
       --s3-endpoint-override string   An alternate url endpoint to send S3 API calls to.
 
 GCP Flags:
-      --gcp-key-path string            Path to file containing Service Account JSON Key.
-      --gcp-bucket-name string         Name of the Google Cloud Storage bucket.
+      --gcp-key-path string            Path to file containing service account JSON key.
+      --gcp-bucket-name string         Name of the Google cloud storage bucket.
       --gcp-endpoint-override string   An alternate url endpoint to send GCP API calls to.
 
 Azure Flags:
       --azure-account-name string     Azure account name for account name, key authorization.
       --azure-account-key string      Azure account key for account name, key authorization.
       --azure-tenant-id string        Azure tenant ID for Azure Active Directory authorization.
-      --azure-client-id string        Azure Client ID for Azure Active Directory authorization.
+      --azure-client-id string        Azure client ID for Azure Active Directory authorization.
       --azure-client-secret string    Azure client secret for Azure Active Directory authorization.
       --azure-endpoint string         Azure endpoint.
       --azure-container-name string   Azure container Name.

--- a/cmd/internal/models/aws_s3.go
+++ b/cmd/internal/models/aws_s3.go
@@ -14,8 +14,36 @@
 
 package models
 
+import (
+	"fmt"
+
+	"github.com/aerospike/backup-go"
+)
+
 type AwsS3 struct {
 	Region   string
 	Profile  string
 	Endpoint string
+}
+
+// LoadSecrets tries to load field values from secret agent.
+func (a *AwsS3) LoadSecrets(cfg *backup.SecretAgentConfig) error {
+	var err error
+
+	a.Region, err = backup.ParseSecret(cfg, a.Region)
+	if err != nil {
+		return fmt.Errorf("failed to load region from secret agent: %w", err)
+	}
+
+	a.Profile, err = backup.ParseSecret(cfg, a.Profile)
+	if err != nil {
+		return fmt.Errorf("failed to load profile from secret agent: %w", err)
+	}
+
+	a.Endpoint, err = backup.ParseSecret(cfg, a.Endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to load endpoint from secret agent: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/internal/models/azure_blob.go
+++ b/cmd/internal/models/azure_blob.go
@@ -14,6 +14,12 @@
 
 package models
 
+import (
+	"fmt"
+
+	"github.com/aerospike/backup-go"
+)
+
 type AzureBlob struct {
 	// Account name + key auth
 	AccountName string
@@ -25,4 +31,46 @@ type AzureBlob struct {
 
 	Endpoint      string
 	ContainerName string
+}
+
+// LoadSecrets tries to load field values from secret agent.
+func (a *AzureBlob) LoadSecrets(cfg *backup.SecretAgentConfig) error {
+	var err error
+
+	a.AccountName, err = backup.ParseSecret(cfg, a.AccountName)
+	if err != nil {
+		return fmt.Errorf("failed to load account name from secret agent: %w", err)
+	}
+
+	a.AccountKey, err = backup.ParseSecret(cfg, a.AccountKey)
+	if err != nil {
+		return fmt.Errorf("failed to load account key from secret agent: %w", err)
+	}
+
+	a.TenantID, err = backup.ParseSecret(cfg, a.TenantID)
+	if err != nil {
+		return fmt.Errorf("failed to load tenant id from secret agent: %w", err)
+	}
+
+	a.ClientID, err = backup.ParseSecret(cfg, a.ClientID)
+	if err != nil {
+		return fmt.Errorf("failed to load client id from secret agent: %w", err)
+	}
+
+	a.ClientSecret, err = backup.ParseSecret(cfg, a.ClientSecret)
+	if err != nil {
+		return fmt.Errorf("failed to load client secret from secret agent: %w", err)
+	}
+
+	a.Endpoint, err = backup.ParseSecret(cfg, a.Endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to load endpoint from secret agent: %w", err)
+	}
+
+	a.ContainerName, err = backup.ParseSecret(cfg, a.ContainerName)
+	if err != nil {
+		return fmt.Errorf("failed to load container name from secret agent: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/internal/models/gcp_storage.go
+++ b/cmd/internal/models/gcp_storage.go
@@ -14,6 +14,12 @@
 
 package models
 
+import (
+	"fmt"
+
+	"github.com/aerospike/backup-go"
+)
+
 type GcpStorage struct {
 	// Path to file containing Service Account JSON Key.
 	KeyFile string
@@ -23,4 +29,26 @@ type GcpStorage struct {
 	// Alternative url.
 	// It is not recommended to use an alternate URL in a production environment.
 	Endpoint string
+}
+
+// LoadSecrets tries to load field values from secret agent.
+func (g *GcpStorage) LoadSecrets(cfg *backup.SecretAgentConfig) error {
+	var err error
+
+	g.KeyFile, err = backup.ParseSecret(cfg, g.KeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to load key file from secret agent: %w", err)
+	}
+
+	g.BucketName, err = backup.ParseSecret(cfg, g.BucketName)
+	if err != nil {
+		return fmt.Errorf("failed to load bucket name from secret agent: %w", err)
+	}
+
+	g.Endpoint, err = backup.ParseSecret(cfg, g.Endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to load endpoint from secret agent: %w", err)
+	}
+
+	return nil
 }

--- a/secret_agent.go
+++ b/secret_agent.go
@@ -124,3 +124,13 @@ func getTlSConfig(caFile *string) (*tls.Config, error) {
 func isSecret(secret string) bool {
 	return strings.HasPrefix(secret, secretPrefix)
 }
+
+// ParseSecret check if string contains secret and tries to load secret from secret agent.
+func ParseSecret(config *SecretAgentConfig, secret string) (string, error) {
+	// If value doesn't contain the secret, we return it as is.
+	if !isSecret(secret) {
+		return secret, nil
+	}
+
+	return getSecret(config, secret)
+}


### PR DESCRIPTION
- support of secret agent configuration for clouds
- you can get any cloud config string from secret agent
example:
`./asbackup --namespace source-ns1 --directory asbackup/asbkp --user tester --password psw --parallel 10 --remove-files --s3-region secrets:test-resource-1:s3-region --s3-profile secrets:test-resource-2:s3-profile --s3-endpoint-override secrets:test-resource-3:s3-endpoint-override --sa-connection-type tcp --sa-address 127.0.0.1 --sa-port 3010`

**Support added on CLI app level, as we initialize readers/writers outside of our backup-go library.**