### PR TITLE
FMWK-613 Restore user keys

### DIFF
--- a/cmd/internal/app/configs.go
+++ b/cmd/internal/app/configs.go
@@ -252,6 +252,7 @@ func mapSecretAgentConfig(s *models.SecretAgent) *backup.SecretAgentConfig {
 
 func mapScanPolicy(b *models.Backup, c *models.Common) (*aerospike.ScanPolicy, error) {
 	p := aerospike.NewScanPolicy()
+	p.SendKey = true
 	p.MaxRecords = b.MaxRecords
 	p.MaxRetries = c.MaxRetries
 	p.SleepBetweenRetries = time.Duration(b.SleepBetweenRetries) * time.Millisecond
@@ -280,6 +281,7 @@ func mapScanPolicy(b *models.Backup, c *models.Common) (*aerospike.ScanPolicy, e
 
 func mapWritePolicy(r *models.Restore, c *models.Common) *aerospike.WritePolicy {
 	p := aerospike.NewWritePolicy(0, 0)
+	p.SendKey = true
 	p.MaxRetries = c.MaxRetries
 	p.TotalTimeout = time.Duration(c.TotalTimeout) * time.Millisecond
 	p.SocketTimeout = time.Duration(c.SocketTimeout) * time.Millisecond

--- a/cmd/internal/app/configs.go
+++ b/cmd/internal/app/configs.go
@@ -252,7 +252,6 @@ func mapSecretAgentConfig(s *models.SecretAgent) *backup.SecretAgentConfig {
 
 func mapScanPolicy(b *models.Backup, c *models.Common) (*aerospike.ScanPolicy, error) {
 	p := aerospike.NewScanPolicy()
-	p.SendKey = true
 	p.MaxRecords = b.MaxRecords
 	p.MaxRetries = c.MaxRetries
 	p.SleepBetweenRetries = time.Duration(b.SleepBetweenRetries) * time.Millisecond

--- a/io/aerospike/record_batch_writer.go
+++ b/io/aerospike/record_batch_writer.go
@@ -77,6 +77,7 @@ func (rw *batchRecordWriter) batchWrite(record *models.Record) *a.BatchWrite {
 
 func batchWritePolicy(writePolicy *a.WritePolicy, r *models.Record) *a.BatchWritePolicy {
 	policy := a.NewBatchWritePolicy()
+	policy.SendKey = true
 	policy.RecordExistsAction = writePolicy.RecordExistsAction
 	policy.Expiration = r.Expiration
 

--- a/tests/test_client.go
+++ b/tests/test_client.go
@@ -202,6 +202,8 @@ func (tc *TestClient) ValidateSIndexes(t assert.TestingT, expected []*models.SIn
 
 // WriteRecords writes the given records to the database.
 func (tc *TestClient) WriteRecords(recs []*a.Record) error {
+	wp := tc.asc.GetDefaultWritePolicy()
+	wp.SendKey = true
 	for _, rec := range recs {
 		err := tc.asc.Put(nil, rec.Key, rec.Bins)
 		if err != nil {
@@ -249,12 +251,14 @@ func (tc *TestClient) ValidateRecords(
 
 	if len(actualRecs) != len(expectedRecs) {
 		t.Errorf("Expected %d records, got %d", len(expectedRecs), len(actualRecs))
+		return
 	}
 
 	for _, expRec := range expectedRecs {
 		actual, ok := actualRecs[string(expRec.Key.Digest())]
 		if !ok {
 			t.Errorf("Expected record not found: %v", expRec.Key)
+			return
 		}
 
 		assert.Equal(t, expRec.Bins, actual.Bins)

--- a/tests/test_client.go
+++ b/tests/test_client.go
@@ -204,6 +204,7 @@ func (tc *TestClient) ValidateSIndexes(t assert.TestingT, expected []*models.SIn
 func (tc *TestClient) WriteRecords(recs []*a.Record) error {
 	wp := tc.asc.GetDefaultWritePolicy()
 	wp.SendKey = true
+
 	for _, rec := range recs {
 		err := tc.asc.Put(nil, rec.Key, rec.Bins)
 		if err != nil {


### PR DESCRIPTION
- we skipped restore of PK on restore operation
- also we don't need to set sendKey on Scan:
`If the key is sent on a read, the server will generate the hash digest from the key and validate that digest with the digest sent by the client. Unless this is the explicit intent of the developer, avoid sending the key on reads. The default is to not send the user defined key.`