### PR TITLE
APPS-1385 Fix the ASB encoding of float values

### DIFF
--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -253,7 +253,7 @@ func writeBinInt[T binTypesInt](name string, v T, w io.Writer) (int, error) {
 }
 
 func writeBinFloat(name string, v float64, w io.Writer) (int, error) {
-	return writeBytes(w, binFloatTypePrefix, escapeASB(name), []byte(fmt.Sprintf(" %f", v)))
+	return writeBytes(w, binFloatTypePrefix, escapeASB(name), space, []byte(strconv.FormatFloat(v, 'g', -1, 64)))
 }
 
 func writeBinString(name, v string, w io.Writer) (int, error) {

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -996,8 +996,8 @@ func Test_writeBinFloat(t *testing.T) {
 				name: "binName",
 				v:    1234.5678,
 			},
-			want:  len("- D binName 1234.567800\n"),
-			wantW: "- D binName 1234.567800\n",
+			want:  len("- D binName 1234.5678\n"),
+			wantW: "- D binName 1234.5678\n",
 		},
 		{
 			name: "positive escaped",
@@ -1005,8 +1005,8 @@ func Test_writeBinFloat(t *testing.T) {
 				name: "b\nin\\Nam e",
 				v:    1234.5678,
 			},
-			want:  len("- D b\\\nin\\\\Nam\\ e 1234.567800\n"),
-			wantW: "- D b\\\nin\\\\Nam\\ e 1234.567800\n",
+			want:  len("- D b\\\nin\\\\Nam\\ e 1234.5678\n"),
+			wantW: "- D b\\\nin\\\\Nam\\ e 1234.5678\n",
 		},
 	}
 	for _, tt := range tests {

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -362,7 +362,39 @@ func Test_binToASB(t *testing.T) {
 				k: "binName",
 				v: 123.456,
 			},
-			want: []byte("- D binName 123.456000\n"),
+			want: []byte("- D binName 123.456\n"),
+		},
+		{
+			name: "positive float scientific notation long bin",
+			args: args{
+				k: "binName",
+				v: 8.699637788021931e-151,
+			},
+			want: []byte("- D binName 8.699637788021931e-151\n"),
+		},
+		{
+			name: "positive float scientific notation short bin",
+			args: args{
+				k: "binName",
+				v: 2.000511e-212,
+			},
+			want: []byte("- D binName 2.000511e-212\n"),
+		},
+		{
+			name: "negative float scientific notation long bin",
+			args: args{
+				k: "binName",
+				v: -9.799243036278548e-17,
+			},
+			want: []byte("- D binName -9.799243036278548e-17\n"),
+		},
+		{
+			name: "negative float scientific notation short bin",
+			args: args{
+				k: "binName",
+				v: -2.490355e+26,
+			},
+			want: []byte("- D binName -2.490355e+26\n"),
 		},
 		{
 			name: "positive negative float bin",
@@ -370,7 +402,7 @@ func Test_binToASB(t *testing.T) {
 				k: "binName",
 				v: -123.456,
 			},
-			want: []byte("- D binName -123.456000\n"),
+			want: []byte("- D binName -123.456\n"),
 		},
 		{
 			name: "positive string bin",


### PR DESCRIPTION
- fix encoder for float values
- I removed 000 from old tests, because now we encoding will work in correct way and it won't append zeroes