### PR TITLE
APPS-1500 Validate record exists policy for asbx restore

### DIFF
--- a/config_restore.go
+++ b/config_restore.go
@@ -178,5 +178,15 @@ func (c *ConfigRestore) isValidForASBX() error {
 		return fmt.Errorf("extra ttl value is not supported for ASBX")
 	}
 
+	if c.WritePolicy != nil {
+		if c.WritePolicy.RecordExistsAction == a.REPLACE {
+			return fmt.Errorf("replace exists action is not supported for ASBX")
+		}
+
+		if c.WritePolicy.RecordExistsAction == a.CREATE_ONLY {
+			return fmt.Errorf("unique is not supported for ASBX")
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
- throw an error on asbx restore with -u or -r flags