### PR TITLE
APPS-1514 Fix backup estimate report format

### DIFF
--- a/cmd/internal/app/reports.go
+++ b/cmd/internal/app/reports.go
@@ -125,7 +125,7 @@ func printEstimateReport(estimate uint64) {
 	fmt.Println(headerEstimateReport)
 	fmt.Println(strings.Repeat("-", len(headerEstimateReport)))
 
-	printMetric("File size: %d bytes\n", estimate)
+	printMetric("File size (bytes)", estimate)
 }
 
 func printMetric(key string, value any) {


### PR DESCRIPTION
Now estimate report look like this:

```
Estimate Report
---------------
File size (bytes):    0
```