### PR TITLE
APPS-1596 Use storage class to configure Azure tier

### DIFF
--- a/io/storage/azure/blob/writer.go
+++ b/io/storage/azure/blob/writer.go
@@ -98,9 +98,9 @@ func NewWriter(
 		}
 	}
 
-	if w.AccessTier != "" {
+	if w.StorageClass != "" {
 		// validation.
-		tier, err := parseAccessTier(w.AccessTier)
+		tier, err := parseAccessTier(w.StorageClass)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse access tier: %w", err)
 		}

--- a/io/storage/options.go
+++ b/io/storage/options.go
@@ -159,7 +159,7 @@ func WithUploadConcurrency(v int) Opt {
 }
 
 // WithStorageClass sets the storage class.
-// Is applicable only for S3.
+// For writers, files are saved to the specified class (in case of Azure it will be tier).
 func WithStorageClass(class string) Opt {
 	return func(r *Options) {
 		r.StorageClass = class
@@ -168,7 +168,6 @@ func WithStorageClass(class string) Opt {
 
 // WithAccessTier sets the access tier for archived files.
 // For readers, archived files are restored to the specified tier.
-// For writers, files are saved to the specified tier.
 func WithAccessTier(tier string) Opt {
 	return func(r *Options) {
 		r.AccessTier = tier


### PR DESCRIPTION
Now, for writers we should init: WithStorageClass().
Fow readers we should init with WithAccessTier().
As we restore from storage class to tier.