### PR TITLE
FMWK-741 Optimize backup records number estimation

### DIFF
--- a/cmd/internal/app/reports.go
+++ b/cmd/internal/app/reports.go
@@ -50,7 +50,7 @@ func printBackupReport(stats *bModels.BackupStats, isXdr bool) {
 	fmt.Println()
 
 	printMetric("Bytes Written", stats.GetBytesWritten())
-	printMetric("Total Records", stats.TotalRecords)
+	printMetric("Total Records", stats.TotalRecords.Load())
 	printMetric("Files Written", stats.GetFileCount())
 }
 

--- a/config_backup.go
+++ b/config_backup.go
@@ -170,8 +170,7 @@ func (c *ConfigBackup) isStateContinue() bool {
 	return c.StateFile != "" && c.Continue
 }
 
-func (c *ConfigBackup) isFullBackup() bool {
-	// full backup doesn't have a lower bound.
+func (c *ConfigBackup) withoutFilter() bool {
 	return c.ModAfter == nil && c.ScanPolicy.FilterExpression == nil
 }
 

--- a/config_backup.go
+++ b/config_backup.go
@@ -172,7 +172,7 @@ func (c *ConfigBackup) isStateContinue() bool {
 
 func (c *ConfigBackup) isFullBackup() bool {
 	// full backup doesn't have a lower bound.
-	return c.ModAfter == nil && c.isDefaultPartitionFilter() && c.ScanPolicy.FilterExpression == nil
+	return c.ModAfter == nil && c.ScanPolicy.FilterExpression == nil
 }
 
 // validate validates the ConfigBackup.

--- a/config_test.go
+++ b/config_test.go
@@ -27,7 +27,7 @@ import (
 func TestBackupConfig_validate(t *testing.T) {
 	config := NewDefaultBackupConfig()
 	assert.NoError(t, config.validate())
-	assert.Equal(t, true, config.isFullBackup())
+	assert.Equal(t, true, config.withoutFilter())
 
 	config.ParallelRead = -1
 	assert.ErrorContains(t, config.validate(), "parallel")

--- a/handler_backup.go
+++ b/handler_backup.go
@@ -320,7 +320,7 @@ func (bh *BackupHandler) backupSync(ctx context.Context) error {
 func (bh *BackupHandler) countRecords(ctx context.Context) {
 	records, err := bh.recordHandler.countRecords(ctx, bh.infoClient)
 	if err != nil {
-		bh.logger.Error("failed to count records", "error", err)
+		bh.logger.Error("failed to count records", slog.Any("error", err))
 	}
 
 	bh.stats.TotalRecords.Store(records)

--- a/handler_backup_records_count.go
+++ b/handler_backup_records_count.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (bh *backupRecordsHandler) countRecords(ctx context.Context, infoClient *asinfo.InfoClient) (uint64, error) {
-	if bh.config.isFullBackup() {
+	if bh.config.withoutFilter() {
 		return bh.countUsingInfoClient(infoClient)
 	}
 

--- a/handler_backup_records_count.go
+++ b/handler_backup_records_count.go
@@ -1,0 +1,147 @@
+// Copyright 2024 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	a "github.com/aerospike/aerospike-client-go/v8"
+	"github.com/aerospike/backup-go/internal/asinfo"
+	"github.com/aerospike/backup-go/io/aerospike"
+	"io"
+	"math/rand"
+)
+
+func (bh *backupRecordsHandler) countRecords(ctx context.Context, infoClient *asinfo.InfoClient) (uint64, error) {
+	if bh.config.isFullBackup() {
+		return bh.countUsingInfoClient(infoClient)
+	}
+
+	return bh.countRecordsUsingScan(ctx)
+}
+
+func (bh *backupRecordsHandler) countUsingInfoClient(infoClient *asinfo.InfoClient) (uint64, error) {
+	totalRecordCount, err := infoClient.GetRecordCount(bh.config.Namespace, bh.config.SetList)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get record count: %w", err)
+	}
+
+	partitionsToScan := uint64(sumPartition(bh.config.PartitionFilters))
+	return totalRecordCount * MaxPartitions / partitionsToScan, nil
+}
+
+func (bh *backupRecordsHandler) countRecordsUsingScan(ctx context.Context) (uint64, error) {
+	scanPolicy := *bh.config.ScanPolicy
+
+	scanPolicy.IncludeBinData = false
+	scanPolicy.MaxRecords = 0
+
+	if bh.config.isParalleledByNodes() {
+		return bh.countRecordsUsingScanByNodes(ctx, &scanPolicy)
+	}
+
+	return bh.countRecordsUsingScanByPartitions(ctx, &scanPolicy)
+}
+
+func (bh *backupRecordsHandler) countRecordsUsingScanByPartitions(ctx context.Context, scanPolicy *a.ScanPolicy,
+) (uint64, error) {
+	var count uint64
+
+	partitionFilter := randomPartition(bh.config.PartitionFilters)
+
+	readerConfig := bh.recordReaderConfigForPartitions(partitionFilter, scanPolicy)
+	recordReader := aerospike.NewRecordReader(ctx, bh.aerospikeClient, readerConfig, bh.logger)
+	defer recordReader.Close()
+
+	for {
+		if _, err := recordReader.Read(); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return 0, fmt.Errorf("error during records counting: %w", err)
+		}
+
+		count++
+	}
+
+	return count * uint64(sumPartition(bh.config.PartitionFilters)), nil
+}
+
+func (bh *backupRecordsHandler) countRecordsUsingScanByNodes(ctx context.Context, scanPolicy *a.ScanPolicy,
+) (uint64, error) {
+	nodes, err := bh.getNodes()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get nodes: %w", err)
+	}
+
+	randomIndex := rand.Intn(len(nodes))
+	randomNode := []*a.Node{nodes[randomIndex]}
+	readerConfig := bh.recordReaderConfigForNode(randomNode, scanPolicy)
+	recordReader := aerospike.NewRecordReader(ctx, bh.aerospikeClient, readerConfig, bh.logger)
+	defer recordReader.Close()
+
+	var count uint64
+	for {
+		if _, err := recordReader.Read(); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return 0, fmt.Errorf("error during records counting: %w", err)
+		}
+
+		count++
+	}
+
+	return count * uint64(len(nodes)), nil
+}
+
+// randomPartition returns random partition from filters list.
+func randomPartition(partitionFilters []*a.PartitionFilter) *a.PartitionFilter {
+	if len(partitionFilters) == 0 { // no filter => return any random partition.
+		return a.NewPartitionFilterById(rand.Intn(MaxPartitions))
+	}
+
+	allPartitionIDs := make([]int, 0, sumPartition(partitionFilters))
+
+	for _, pf := range partitionFilters {
+		for i := 0; i < pf.Count; i++ {
+			partitionID := pf.Begin + i
+			allPartitionIDs = append(allPartitionIDs, partitionID)
+		}
+	}
+
+	randomIndex := rand.Intn(len(allPartitionIDs))
+	randomPartitionID := allPartitionIDs[randomIndex]
+
+	return a.NewPartitionFilterById(randomPartitionID)
+}
+
+// sumPartition returns total number of partitions in filters list.
+func sumPartition(partitionFilters []*a.PartitionFilter) int {
+	if len(partitionFilters) == 0 { // no filter => scan all partitions.
+		return MaxPartitions
+	}
+
+	var totalPartitionCount int
+
+	for _, pf := range partitionFilters {
+		totalPartitionCount += pf.Count
+	}
+
+	return totalPartitionCount
+}

--- a/handler_backup_records_count.go
+++ b/handler_backup_records_count.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"math/rand"
+
 	a "github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go/internal/asinfo"
 	"github.com/aerospike/backup-go/io/aerospike"
-	"io"
-	"math/rand"
 )
 
 func (bh *backupRecordsHandler) countRecords(ctx context.Context, infoClient *asinfo.InfoClient) (uint64, error) {

--- a/handler_backup_records_count.go
+++ b/handler_backup_records_count.go
@@ -118,6 +118,7 @@ func (bh *backupRecordsHandler) countRecordsUsingScanByNodes(ctx context.Context
 // randomPartition returns random partition from filters list.
 func randomPartition(partitionFilters []*a.PartitionFilter) *a.PartitionFilter {
 	if len(partitionFilters) == 0 { // no filter => return any random partition.
+		// #nosec G404
 		return a.NewPartitionFilterById(rand.Intn(MaxPartitions))
 	}
 

--- a/handler_backup_records_count.go
+++ b/handler_backup_records_count.go
@@ -89,6 +89,7 @@ func (bh *backupRecordsHandler) countRecordsUsingScanByNodes(ctx context.Context
 		return 0, fmt.Errorf("failed to get nodes: %w", err)
 	}
 
+	// #nosec G404
 	randomIndex := rand.Intn(len(nodes))
 	randomNode := []*a.Node{nodes[randomIndex]}
 	readerConfig := bh.recordReaderConfigForNode(randomNode, scanPolicy)
@@ -126,6 +127,7 @@ func randomPartition(partitionFilters []*a.PartitionFilter) *a.PartitionFilter {
 		}
 	}
 
+	// #nosec G404
 	randomIndex := rand.Intn(len(allPartitionIDs))
 	randomPartitionID := allPartitionIDs[randomIndex]
 

--- a/handler_backup_records_count.go
+++ b/handler_backup_records_count.go
@@ -41,6 +41,7 @@ func (bh *backupRecordsHandler) countUsingInfoClient(infoClient *asinfo.InfoClie
 	}
 
 	partitionsToScan := uint64(sumPartition(bh.config.PartitionFilters))
+
 	return totalRecordCount * MaxPartitions / partitionsToScan, nil
 }
 
@@ -62,8 +63,8 @@ func (bh *backupRecordsHandler) countRecordsUsingScanByPartitions(ctx context.Co
 	var count uint64
 
 	partitionFilter := randomPartition(bh.config.PartitionFilters)
-
 	readerConfig := bh.recordReaderConfigForPartitions(partitionFilter, scanPolicy)
+
 	recordReader := aerospike.NewRecordReader(ctx, bh.aerospikeClient, readerConfig, bh.logger)
 	defer recordReader.Close()
 
@@ -93,10 +94,12 @@ func (bh *backupRecordsHandler) countRecordsUsingScanByNodes(ctx context.Context
 	randomIndex := rand.Intn(len(nodes))
 	randomNode := []*a.Node{nodes[randomIndex]}
 	readerConfig := bh.recordReaderConfigForNode(randomNode, scanPolicy)
+
 	recordReader := aerospike.NewRecordReader(ctx, bh.aerospikeClient, readerConfig, bh.logger)
 	defer recordReader.Close()
 
 	var count uint64
+
 	for {
 		if _, err := recordReader.Read(); err != nil {
 			if errors.Is(err, io.EOF) {

--- a/handler_backup_xdr.go
+++ b/handler_backup_xdr.go
@@ -151,13 +151,12 @@ func (bh *HandlerBackupXDR) run() {
 }
 
 func (bh *HandlerBackupXDR) backup(ctx context.Context) error {
-	var err error
-
 	// Count total records.
-	bh.stats.TotalRecords, err = bh.infoClient.GetRecordCount(bh.config.Namespace, nil)
+	records, err := bh.infoClient.GetRecordCount(bh.config.Namespace, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get records count: %w", err)
 	}
+	bh.stats.TotalRecords.Store(records)
 
 	// Read workers.
 	readWorkers, err := bh.readProcessor.newReadWorkersXDR(ctx)

--- a/handler_backup_xdr.go
+++ b/handler_backup_xdr.go
@@ -156,6 +156,7 @@ func (bh *HandlerBackupXDR) backup(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get records count: %w", err)
 	}
+
 	bh.stats.TotalRecords.Store(records)
 
 	// Read workers.

--- a/models/backup_stats.go
+++ b/models/backup_stats.go
@@ -24,7 +24,7 @@ type BackupStats struct {
 	*commonStats
 	fileCount atomic.Uint64
 	// total number of records in database
-	TotalRecords uint64
+	TotalRecords atomic.Uint64
 }
 
 // NewBackupStats returns new backup stats.
@@ -62,7 +62,7 @@ func SumBackupStats(stats ...*BackupStats) *BackupStats {
 
 		result.commonStats = sumCommonStats(result.commonStats, stat.commonStats)
 		result.fileCount.Add(stat.GetFileCount())
-		result.TotalRecords += stat.TotalRecords
+		result.TotalRecords.Add(stat.TotalRecords.Load())
 	}
 
 	return result


### PR DESCRIPTION
1) run estimate counting in goroutine
2) if scan by node — only scan one node
3) if scan by partition and filter by time/expression — only scan one partition
4) if full backup and scan by partition — use infocommand and calculate percentage.