### PR TITLE
APPS-1574 Add MAX_RETRIES_EXCEEDED to retriable errors

### DIFF
--- a/io/aerospike/record_batch_writer.go
+++ b/io/aerospike/record_batch_writer.go
@@ -237,6 +237,7 @@ func mapWriteToBatchPolicy(w *a.WritePolicy) *a.BatchPolicy {
 	bp := a.NewBatchPolicy()
 	bp.SocketTimeout = w.SocketTimeout
 	bp.TotalTimeout = w.TotalTimeout
+	bp.MaxRetries = w.MaxRetries
 
 	return bp
 }

--- a/io/aerospike/record_batch_writer.go
+++ b/io/aerospike/record_batch_writer.go
@@ -237,7 +237,6 @@ func mapWriteToBatchPolicy(w *a.WritePolicy) *a.BatchPolicy {
 	bp := a.NewBatchPolicy()
 	bp.SocketTimeout = w.SocketTimeout
 	bp.TotalTimeout = w.TotalTimeout
-	bp.MaxRetries = w.MaxRetries
 
 	return bp
 }

--- a/io/aerospike/restore_writer.go
+++ b/io/aerospike/restore_writer.go
@@ -200,6 +200,7 @@ func shouldRetry(err a.Error) bool {
 		atypes.SERVER_NOT_AVAILABLE,
 		atypes.BATCH_FAILED,
 		atypes.MAX_ERROR_RATE,
+		atypes.MAX_RETRIES_EXCEEDED,
 	)
 }
 


### PR DESCRIPTION
- Add MAX_RETRIES_EXCEEDED to retriable errors, so we use our own retry mechanism
This will allow client to reconnect, when he lost connection during node restart