### PR TITLE
APPS-1716 Remove Total Records from report

### DIFF
--- a/backup_restore_test.go
+++ b/backup_restore_test.go
@@ -16,7 +16,6 @@ package backup
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -32,6 +31,7 @@ import (
 	"github.com/aerospike/backup-go/io/storage/local"
 	"github.com/aerospike/backup-go/models"
 	"github.com/aerospike/backup-go/tests"
+	"github.com/segmentio/asm/base64"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cmd/asrestore/main.go
+++ b/cmd/asrestore/main.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/aerospike/backup-go/cmd/asrestore/cmd"
 )
@@ -33,12 +35,15 @@ func main() {
 	// Initializing context with cancel for graceful shutdown.
 	ctx, cancel := context.WithCancel(context.Background())
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, os.Kill)
 
 	go func() {
 		sig := <-sigChan
 		log.Printf("stopping asrestore: %v\n", sig)
 		cancel()
+		// Don't hang if one of the routines is asleep. Wait 1 second and exit.
+		time.Sleep(time.Second)
+		os.Exit(1)
 	}()
 
 	// Return c to log errors properly.

--- a/cmd/internal/logging/reports.go
+++ b/cmd/internal/logging/reports.go
@@ -63,7 +63,6 @@ func printBackupReport(stats *bModels.BackupStats, isXdr bool) {
 	fmt.Println()
 
 	printMetric("Bytes Written", stats.GetBytesWritten())
-	printMetric("Total Records", stats.TotalRecords.Load())
 	printMetric("Files Written", stats.GetFileCount())
 }
 
@@ -80,7 +79,6 @@ func logBackupReport(stats *bModels.BackupStats, isXdr bool, logger *slog.Logger
 		slog.Uint64("s_index_read", uint64(stats.GetSIndexes())),
 		slog.Uint64("udf_read", uint64(stats.GetUDFs())),
 		slog.Uint64("bytes_written", stats.GetBytesWritten()),
-		slog.Uint64("total_records", stats.TotalRecords.Load()),
 		slog.Uint64("files_written", stats.GetFileCount()),
 	)
 }

--- a/internal/asinfo/info_client.go
+++ b/internal/asinfo/info_client.go
@@ -15,7 +15,6 @@
 package asinfo
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"math"
@@ -26,6 +25,7 @@ import (
 
 	a "github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go/models"
+	"github.com/segmentio/asm/base64"
 )
 
 const (

--- a/internal/asinfo/info_client_test.go
+++ b/internal/asinfo/info_client_test.go
@@ -15,7 +15,6 @@
 package asinfo
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"reflect"
@@ -24,6 +23,7 @@ import (
 	a "github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go/internal/asinfo/mocks"
 	"github.com/aerospike/backup-go/models"
+	"github.com/segmentio/asm/base64"
 	"github.com/stretchr/testify/require"
 )
 

--- a/io/aerospike/xdr/parser_test.go
+++ b/io/aerospike/xdr/parser_test.go
@@ -14,7 +14,6 @@
 package xdr
 
 import (
-	"encoding/base64"
 	"errors"
 	"net"
 	"testing"
@@ -22,6 +21,7 @@ import (
 
 	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go/models"
+	"github.com/segmentio/asm/base64"
 	"github.com/stretchr/testify/require"
 )
 

--- a/io/aerospike/xdr/tcp_server_test.go
+++ b/io/aerospike/xdr/tcp_server_test.go
@@ -16,7 +16,6 @@ package xdr
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"net"
@@ -25,6 +24,7 @@ import (
 	"time"
 
 	"github.com/aerospike/backup-go/internal/metrics"
+	"github.com/segmentio/asm/base64"
 	"github.com/stretchr/testify/require"
 )
 

--- a/io/encoding/asb/decode_test.go
+++ b/io/encoding/asb/decode_test.go
@@ -15,7 +15,6 @@
 package asb
 
 import (
-	"encoding/base64"
 	"fmt"
 	"io"
 	"math"
@@ -26,6 +25,7 @@ import (
 	a "github.com/aerospike/aerospike-client-go/v8"
 	particleType "github.com/aerospike/aerospike-client-go/v8/types/particle_type"
 	"github.com/aerospike/backup-go/models"
+	"github.com/segmentio/asm/base64"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -17,7 +17,6 @@ package asb
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/base64"
 	"fmt"
 	mRand "math/rand"
 	"reflect"
@@ -29,6 +28,7 @@ import (
 	a "github.com/aerospike/aerospike-client-go/v8"
 	particleType "github.com/aerospike/aerospike-client-go/v8/types/particle_type"
 	"github.com/aerospike/backup-go/models"
+	"github.com/segmentio/asm/base64"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )

--- a/io/encoding/asbx/encode_decode_test.go
+++ b/io/encoding/asbx/encode_decode_test.go
@@ -16,13 +16,13 @@ package asbx
 
 import (
 	"bytes"
-	"encoding/base64"
 	"io"
 	"testing"
 
 	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go/internal/util"
 	"github.com/aerospike/backup-go/models"
+	"github.com/segmentio/asm/base64"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/secret-agent/client.go
+++ b/pkg/secret-agent/client.go
@@ -17,11 +17,11 @@ package secret_agent
 
 import (
 	"crypto/tls"
-	"encoding/base64"
 	"fmt"
 	"time"
 
 	"github.com/aerospike/backup-go/pkg/secret-agent/connection"
+	"github.com/segmentio/asm/base64"
 )
 
 const (

--- a/shared.go
+++ b/shared.go
@@ -15,12 +15,12 @@
 package backup
 
 import (
-	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
 
 	a "github.com/aerospike/aerospike-client-go/v8"
+	"github.com/segmentio/asm/base64"
 )
 
 func handlePanic(errors chan<- error, logger *slog.Logger) {


### PR DESCRIPTION
- removed total records from report not to confuse end user (as this number is approximate and is used for estimates)
- replaced base64 lib in tests and other places
- improved graceful shutdown