### PR TITLE
APPS-1798 Remove context error check in IO operations

### DIFF
--- a/io/aerospike/record_reader.go
+++ b/io/aerospike/record_reader.go
@@ -136,14 +136,10 @@ func (r *RecordReader) Read(ctx context.Context) (*models.Token, error) {
 		return r.readPage(ctx)
 	}
 
-	return r.read(ctx)
+	return r.read()
 }
 
-func (r *RecordReader) read(ctx context.Context) (*models.Token, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-
+func (r *RecordReader) read() (*models.Token, error) {
 	if !r.isScanStarted() {
 		scan, err := r.startScan()
 		if err != nil {

--- a/io/aerospike/restore_writer.go
+++ b/io/aerospike/restore_writer.go
@@ -134,11 +134,7 @@ func newRecordWriter(
 }
 
 // Write writes the types from the models package to an Aerospike DB.
-func (rw *RestoreWriter[T]) Write(ctx context.Context, data T) (int, error) {
-	if ctx.Err() != nil {
-		return 0, ctx.Err()
-	}
-
+func (rw *RestoreWriter[T]) Write(_ context.Context, data T) (int, error) {
 	switch v := any(data).(type) {
 	case *models.ASBXToken:
 		// Logic for ASBXToken


### PR DESCRIPTION
Remove context check before record insert.
I left ) context.Context to satisfy Writer interface, as for file writers we use context for cloud writes