### PR TITLE
APPS-1807 Improve invalid token error text

### DIFF
--- a/io/encoding/asb/decode.go
+++ b/io/encoding/asb/decode.go
@@ -196,6 +196,7 @@ func NewDecoder[T models.TokenConstraint](src io.Reader, fileName string) (*Deco
 	}
 
 	asb.header, err = asb.readHeader()
+
 	switch {
 	case err == nil: // ok
 	case errors.Is(err, errInvalidToken):


### PR DESCRIPTION
Error example:
```time=2025-07-13T17:18:11.631+03:00 level=ERROR msg="failed to execute" error="restore failed: failed to perform asb restore: failed to read data: error while reading 0_source-ns1_14.asb header: invalid token, read qwesdfw, expected Version. This may happen if the file was compressed/encrypted and the restore config does not contain the proper compression/encryption policy, or the file is corrupted"```