### PR TITLE
FMWK-882 Fix goroutine leak on successful backup completion

### DIFF
--- a/handler_backup.go
+++ b/handler_backup.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"log/slog"
 	"math"
-	"sync"
 	"sync/atomic"
 
 	"github.com/aerospike/backup-go/internal/bandwidth"
@@ -62,9 +61,7 @@ type Writer interface {
 
 // BackupHandler handles a backup job.
 type BackupHandler struct {
-	// Global backup context for a whole backup process.
-	ctx    context.Context
-	cancel context.CancelFunc
+	*handlerBase
 
 	readerProcessor *recordReaderProcessor[*models.Token]
 	writerProcessor *fileWriterProcessor[*models.Token]
@@ -78,15 +75,11 @@ type BackupHandler struct {
 	limiter                *bandwidth.Limiter
 	infoClient             InfoGetter
 	scanLimiter            *semaphore.Weighted
-	errors                 chan error
-	done                   chan struct{}
 	id                     string
 
 	stats *models.BackupStats
 	// Backup state for continuation.
 	state *State
-	// For graceful shutdown.
-	wg sync.WaitGroup
 
 	pl atomic.Pointer[pipe.Pipe[*models.Token]]
 
@@ -117,17 +110,18 @@ func newBackupHandler(
 	logger = logging.WithHandler(logger, id, logging.HandlerTypeBackup, storageType)
 	metricMessage := fmt.Sprintf("%s metrics %s", logging.HandlerTypeBackup, id)
 
-	// Derive a new cancellable context from the existing one.
-	ctx, cancel := context.WithCancel(ctx)
+	// Create handler base first to get the derived context.
+	base := newHandlerBase(ctx)
 
+	// State is used to store the backup state and resume the backup operation.
 	var state *State
 
 	if config.StateFile != "" {
 		var err error
 
-		state, err = NewState(ctx, config, reader, writer, logger)
+		state, err = NewState(base.ctx, config, reader, writer, logger)
 		if err != nil {
-			cancel()
+			base.cancel()
 			return nil, fmt.Errorf("failed to initialize state: %w", err)
 		}
 
@@ -136,15 +130,15 @@ func newBackupHandler(
 			// change filters in config.
 			config.PartitionFilters, err = state.loadPartitionFilters()
 			if err != nil {
-				cancel()
+				base.cancel()
 				return nil, fmt.Errorf("failed to load partition filters: %w", err)
 			}
 		}
 	}
 
-	hasExpressionSIndex, err := infoClient.HasExpressionSIndex(ctx, config.Namespace)
+	hasExpressionSIndex, err := infoClient.HasExpressionSIndex(base.ctx, config.Namespace)
 	if err != nil {
-		cancel()
+		base.cancel()
 		return nil, fmt.Errorf("failed to check if expression sindex exists: %w", err)
 	}
 
@@ -153,7 +147,7 @@ func newBackupHandler(
 	stats := models.NewBackupStats()
 
 	rpsCollector := metrics.NewCollector(
-		ctx,
+		base.ctx,
 		logger,
 		metrics.RecordsPerSecond,
 		metricMessage,
@@ -161,7 +155,7 @@ func newBackupHandler(
 	)
 
 	kbpsCollector := metrics.NewCollector(
-		ctx,
+		base.ctx,
 		logger,
 		metrics.KilobytesPerSecond,
 		metricMessage,
@@ -182,13 +176,12 @@ func newBackupHandler(
 
 	limiter, err := bandwidth.NewLimiter(config.Bandwidth)
 	if err != nil {
-		cancel()
+		base.cancel()
 		return nil, fmt.Errorf("failed to create bandwidth limiter: %w", err)
 	}
 
 	bh := &BackupHandler{
-		ctx:                    ctx,
-		cancel:                 cancel,
+		handlerBase:            base,
 		config:                 config,
 		aerospikeClient:        ac,
 		id:                     id,
@@ -204,8 +197,6 @@ func newBackupHandler(
 		stats:                  stats,
 		rpsCollector:           rpsCollector,
 		kbpsCollector:          kbpsCollector,
-		errors:                 make(chan error, 1),
-		done:                   make(chan struct{}, 1),
 	}
 
 	writerProcessor, err := newFileWriterProcessor[*models.Token](
@@ -224,7 +215,7 @@ func newBackupHandler(
 		logger,
 	)
 	if err != nil {
-		cancel()
+		bh.cancel()
 		return nil, err
 	}
 
@@ -469,41 +460,17 @@ func (bh *BackupHandler) GetStats() *models.BackupStats {
 
 // Wait waits for the backup job to complete and returns an error if the job failed.
 func (bh *BackupHandler) Wait(ctx context.Context) error {
-	var err error
-
-	select {
-	case <-bh.ctx.Done():
-		// When global context is done, wait until all routine finish their work properly.
-		// Global context - is context that was passed to Backup() method.
-		err = bh.ctx.Err()
-	case <-ctx.Done():
-		// When local context is done, we cancel global context.
-		// Then wait until all routines finish their work properly.
-		// Local context - is context that was passed to Wait() method.
-		bh.cancel()
-
-		err = ctx.Err()
-	case err = <-bh.errors:
-		// On error, we cancel global context.
-		// To stop all goroutines and prevent leaks.
-		bh.cancel()
-	case <-bh.done: // Success
-		bh.cancel() // cancel global context to stop all goroutines and prevent leaks.
-	}
-
-	// Wait when all routines ended.
-	bh.wg.Wait()
+	err := bh.waitForCompletion(ctx)
 
 	// If the err is nil, we can remove the state file.
 	if err == nil && bh.state != nil {
-		// Clen only if err == nil and state is not nil.
+		// Clean only if err == nil and state is not nil.
 		if err = bh.state.cleanup(ctx); err != nil {
 			bh.logger.Error("failed to cleanup state", slog.Any("error", err))
 		}
 	}
 
-	// Clean.
-	bh.cleanup()
+	bh.cleanup() // clean up resources.
 
 	return err
 }

--- a/handler_backup.go
+++ b/handler_backup.go
@@ -488,6 +488,7 @@ func (bh *BackupHandler) Wait(ctx context.Context) error {
 		// To stop all goroutines and prevent leaks.
 		bh.cancel()
 	case <-bh.done: // Success
+		bh.cancel() // cancel global context to stop all goroutines and prevent leaks.
 	}
 
 	// Wait when all routines ended.

--- a/handler_backup_test.go
+++ b/handler_backup_test.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	a "github.com/aerospike/aerospike-client-go/v8"
+	"github.com/aerospike/backup-go/io/storage/options"
+	"github.com/aerospike/backup-go/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupHandler_GoroutineLeak_OnSuccess(t *testing.T) {
+	t.Parallel()
+
+	testDir := t.TempDir()
+	stateFile := filepath.Join(testDir, "state_file")
+
+	// Count goroutines before test
+	initialGoroutines := runtime.NumGoroutine()
+
+	// Setup mocks
+	mockAerospikeClient := mocks.NewMockAerospikeClient(t)
+	mockWriter := mocks.NewMockWriter(t)
+	mockReader := mocks.NewMockStreamingReader(t)
+	mockInfoGetter := mocks.NewMockInfoGetter(t)
+
+	// Configure mock expectations
+	mockWriter.EXPECT().GetType().Return("local").Maybe()
+	mockWriter.EXPECT().GetOptions().Return(options.Options{
+		IsDir: true,
+	}).Maybe()
+	mockWriter.EXPECT().Remove(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockInfoGetter.EXPECT().HasExpressionSIndex(mock.Anything, mock.Anything).Return(false, nil).Maybe()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	cfg := NewDefaultBackupConfig()
+	cfg.Namespace = "test"
+	cfg.StateFile = stateFile
+	cfg.PageSize = 100000
+	cfg.PartitionFilters = []*a.PartitionFilter{
+		NewPartitionFilterByID(1),
+	}
+	cfg.NoRecords = true // Skip actual backup
+	cfg.NoUDFs = true
+	cfg.NoIndexes = true
+
+	// Create backup handler
+	handler, err := newBackupHandler(
+		context.Background(),
+		cfg,
+		mockAerospikeClient,
+		logger,
+		mockWriter,
+		mockReader,
+		nil, // scanLimiter
+		mockInfoGetter,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	// Simulate successful backup completion
+	// This is what happens in handler.run() when backup succeeds
+	handler.done <- struct{}{}
+
+	// Call Wait which should clean up
+	err = handler.Wait(context.Background())
+	require.NoError(t, err)
+
+	// Give goroutines time to exit
+	time.Sleep(200 * time.Millisecond)
+	runtime.GC()
+
+	// Count goroutines after cleanup
+	finalGoroutines := runtime.NumGoroutine()
+	leaked := finalGoroutines - initialGoroutines
+
+	// Spawned goroutines should be cleaned up
+	require.LessOrEqual(t, leaked, 0,
+		"goroutine leak detected: started with %d, ended with %d (leaked %d).",
+		initialGoroutines, finalGoroutines, leaked)
+}

--- a/handler_base.go
+++ b/handler_base.go
@@ -1,0 +1,73 @@
+// Copyright 2024 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"context"
+	"sync"
+)
+
+// handlerBase contains common fields and methods for backup/restore handlers.
+type handlerBase struct {
+	// Global context for the operation.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Channel for errors from the operation.
+	errors chan error
+	// Channel signaling successful completion.
+	done chan struct{}
+
+	// For graceful shutdown.
+	wg sync.WaitGroup
+}
+
+// newHandlerBase creates a new handlerBase with the given context.
+func newHandlerBase(ctx context.Context) *handlerBase {
+	ctx, cancel := context.WithCancel(ctx)
+
+	return &handlerBase{
+		ctx:    ctx,
+		cancel: cancel,
+		errors: make(chan error, 1),
+		done:   make(chan struct{}, 1),
+	}
+}
+
+// waitForCompletion waits for the operation to complete and returns any error.
+// It ensures cancel is called in all paths to prevent goroutine leaks.
+func (h *handlerBase) waitForCompletion(waitCtx context.Context) error {
+	var err error
+
+	select {
+	case <-h.ctx.Done():
+		// Global context is done.
+		err = h.ctx.Err()
+	case <-waitCtx.Done():
+		// Wait context is done.
+		err = waitCtx.Err()
+	case err = <-h.errors:
+		// Operation failed.
+	case <-h.done: // Success.
+	}
+
+	// Always cancel to stop all goroutines and prevent leaks.
+	h.cancel()
+
+	// Wait for all goroutines to finish.
+	h.wg.Wait()
+
+	return err
+}


### PR DESCRIPTION
Ensures `BackupHandler.Wait()` cancels the context when backup succeeds, allowing State goroutines to terminate and preventing resource leaks.