### PR TITLE
Encode token memory optimization

### DIFF
--- a/backup_restore_test.go
+++ b/backup_restore_test.go
@@ -15,6 +15,7 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1217,10 +1218,11 @@ func TestRestoreExpiredRecords(t *testing.T) {
 		}
 
 		token := models.NewRecordToken(modelRec, 0, nil)
-		v, err := encoder.EncodeToken(token)
+		var buf bytes.Buffer
+		err = encoder.EncodeToken(token, &buf)
 		require.NoError(t, err)
 
-		_, err = w.Write(v)
+		_, err = w.Write(buf.Bytes())
 		require.NoError(t, err)
 	}
 

--- a/handler_backup.go
+++ b/handler_backup.go
@@ -15,6 +15,7 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -323,13 +324,13 @@ func (bh *BackupHandler) getEstimateSamples(ctx context.Context, recordsNumber i
 			return nil, nil, fmt.Errorf("failed to process token: %w", err)
 		}
 
-		data, err := bh.encoder.EncodeToken(t)
-		if err != nil {
+		var buf bytes.Buffer
+		if err := bh.encoder.EncodeToken(t, &buf); err != nil {
 			return nil, nil, fmt.Errorf("failed to encode token: %w", err)
 		}
 
-		samples = append(samples, float64(len(data)))
-		samplesData = append(samplesData, data...)
+		samples = append(samples, float64(buf.Len()))
+		samplesData = append(samplesData, buf.Bytes()...)
 	}
 
 	return samples, samplesData, nil

--- a/handler_backup.go
+++ b/handler_backup.go
@@ -309,6 +309,8 @@ func (bh *BackupHandler) getEstimateSamples(ctx context.Context, recordsNumber i
 	// Timestamp processor.
 	tsProcessor := processors.NewVoidTimeSetter[*models.Token](bh.logger)
 
+	var buf bytes.Buffer
+
 	for {
 		t, err := recordReader.Read(ctx)
 		if err != nil {
@@ -324,7 +326,8 @@ func (bh *BackupHandler) getEstimateSamples(ctx context.Context, recordsNumber i
 			return nil, nil, fmt.Errorf("failed to process token: %w", err)
 		}
 
-		var buf bytes.Buffer
+		buf.Reset()
+
 		if err := bh.encoder.EncodeToken(t, &buf); err != nil {
 			return nil, nil, fmt.Errorf("failed to encode token: %w", err)
 		}

--- a/io/encoding/asb/decode.go
+++ b/io/encoding/asb/decode.go
@@ -49,7 +49,47 @@ var (
 			return make([]byte, 0, 64)
 		},
 	}
+	// base64BufferPool is a pool of byte slices used for base64 encoding
+	base64BufferPool = sync.Pool{
+		New: func() any {
+			// The buffer size is arbitrary and will be grown if needed
+			return make([]byte, 0, 1024)
+		},
+	}
 )
+
+// base64Encode encodes the input bytes using base64 encoding.
+// It returns a slice that references a pooled buffer, which must be returned to the pool
+// after use by calling returnBase64Buffer.
+func base64Encode(v []byte) []byte {
+	encodedLen := base64.StdEncoding.EncodedLen(len(v))
+
+	// Get a buffer from the pool
+	buf := base64BufferPool.Get().([]byte)
+
+	// Ensure the buffer is large enough
+	if cap(buf) < encodedLen {
+		// If the buffer is too small, create a new one with sufficient capacity
+		buf = make([]byte, encodedLen)
+	} else {
+		// Otherwise, resize the existing buffer
+		buf = buf[:encodedLen]
+	}
+
+	// Encode the data
+	base64.StdEncoding.Encode(buf, v)
+
+	// Return a slice that references the pooled buffer
+	return buf
+}
+
+// returnBase64Buffer returns the buffer to the pool.
+// This must be called after the buffer returned by base64Encode is no longer needed.
+func returnBase64Buffer(buf []byte) {
+	// Reset length but keep capacity
+	//nolint:staticcheck // We try to decrease allocation, not to make them zero.
+	base64BufferPool.Put(buf[:0])
+}
 
 // returnBigBuffer return buffer to pool.
 func returnBigBuffer(buf []byte) {

--- a/io/encoding/asb/decode_test.go
+++ b/io/encoding/asb/decode_test.go
@@ -15,6 +15,7 @@
 package asb
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -3592,5 +3593,131 @@ func TestNewASBReader(t *testing.T) {
 				t.Errorf("NewASBReader() metadata differs = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestEncodeDecodeRecordRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key, keyErr := a.NewKey("test", "roundtrip", "user-key")
+	if keyErr != nil {
+		t.Fatalf("failed to build key: %v", keyErr)
+	}
+
+	inputToken := models.NewRecordToken(&models.Record{
+		Record: &a.Record{
+			Key: key,
+			Bins: a.BinMap{
+				"bool_bin":   true,
+				"int_bin":    int64(42),
+				"float_bin":  float64(3.14),
+				"string_bin": "hello",
+				"bytes_bin":  []byte("bytes"),
+				"hll_bin":    a.HLLValue("hll-value"),
+				"map_bin": &a.RawBlobValue{
+					ParticleType: particleType.MAP,
+					Data:         []byte{0x81, 0xA1, 'a', 0x01},
+				},
+				"list_bin": &a.RawBlobValue{
+					ParticleType: particleType.LIST,
+					Data:         []byte{0x92, 0x01, 0x02},
+				},
+				"geo_bin": a.GeoJSONValue(`{"type":"Point","coordinates":[1,2]}`),
+				"nil_bin": nil,
+			},
+			Generation: 10,
+		},
+		VoidTime: 100,
+	}, 0, nil)
+
+	encoder := NewEncoder[*models.Token](NewEncoderConfig("test", false, false))
+	var file bytes.Buffer
+	file.Write(encoder.GetHeader(0, true))
+
+	if err := encoder.EncodeToken(inputToken, &file); err != nil {
+		t.Fatalf("failed to encode token: %v", err)
+	}
+
+	decoder, err := NewDecoder[*models.Token](bytes.NewReader(file.Bytes()), testFileName, false, slog.Default())
+	if err != nil {
+		t.Fatalf("failed to create decoder: %v", err)
+	}
+
+	gotToken, err := decoder.NextToken()
+	if err != nil {
+		t.Fatalf("failed to decode token: %v", err)
+	}
+
+	if gotToken.Type != models.TokenTypeRecord {
+		t.Fatalf("unexpected token type: got %v", gotToken.Type)
+	}
+
+	if gotToken.Record.Generation != inputToken.Record.Generation {
+		t.Fatalf("generation mismatch: got %d want %d", gotToken.Record.Generation, inputToken.Record.Generation)
+	}
+
+	if gotToken.Record.VoidTime != inputToken.Record.VoidTime {
+		t.Fatalf("void time mismatch: got %d want %d", gotToken.Record.VoidTime, inputToken.Record.VoidTime)
+	}
+
+	if !reflect.DeepEqual(gotToken.Record.Bins, inputToken.Record.Bins) {
+		t.Fatalf("bins mismatch: got %#v want %#v", gotToken.Record.Bins, inputToken.Record.Bins)
+	}
+}
+
+func BenchmarkDecodeRecordRoundTrip(b *testing.B) {
+	key, keyErr := a.NewKey("test", "bench", "bench-key")
+	if keyErr != nil {
+		b.Fatal(keyErr)
+	}
+
+	token := models.NewRecordToken(&models.Record{
+		Record: &a.Record{
+			Key: key,
+			Bins: a.BinMap{
+				"bool_bin":   true,
+				"int_bin":    int64(42),
+				"string_bin": "hello",
+				"bytes_bin":  []byte("bytes"),
+				"hll_bin":    a.HLLValue("hll"),
+				"map_bin": &a.RawBlobValue{
+					ParticleType: particleType.MAP,
+					Data:         []byte{0x81, 0xA1, 'a', 0x01},
+				},
+				"list_bin": &a.RawBlobValue{
+					ParticleType: particleType.LIST,
+					Data:         []byte{0x92, 0x01, 0x02},
+				},
+			},
+			Generation: 10,
+		},
+		VoidTime: 100,
+	}, 0, nil)
+
+	encoder := NewEncoder[*models.Token](NewEncoderConfig("test", false, false))
+	var payload bytes.Buffer
+	payload.Write(encoder.GetHeader(0, true))
+	if err := encoder.EncodeToken(token, &payload); err != nil {
+		b.Fatal(err)
+	}
+
+	data := payload.Bytes()
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		decoder, err := NewDecoder[*models.Token](bytes.NewReader(data), testFileName, false, slog.Default())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		got, err := decoder.NextToken()
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if got.Type != models.TokenTypeRecord {
+			b.Fatalf("unexpected token type: %v", got.Type)
+		}
 	}
 }

--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -50,8 +49,8 @@ func (e *Encoder[T]) GenerateFilename(prefix, suffix string) string {
 	return prefix + e.config.Namespace + "_" + strconv.FormatInt(e.id.Add(1), 10) + suffix + ".asb"
 }
 
-// EncodeToken encodes a token to the ASB format, writing to the provided writer.
-func (e *Encoder[T]) EncodeToken(token T, w io.Writer) error {
+// EncodeToken encodes a token to the ASB format, writing to the provided buffer.
+func (e *Encoder[T]) EncodeToken(token T, w *bytes.Buffer) error {
 	t, ok := any(token).(*models.Token)
 	if !ok {
 		return fmt.Errorf("unsupported token type %T for ASB encoder", token)
@@ -109,21 +108,21 @@ func (e *Encoder[T]) headerVersion(isRecords bool) string {
 
 // **** META DATA ****
 
-func writeVersionText(asbVersion string, w io.Writer) {
+func writeVersionText(asbVersion string, w *bytes.Buffer) {
 	_, _ = writeBytes(w, tokenVersion, space, []byte(asbVersion))
 }
 
-func writeNamespaceMetaText(namespace string, w io.Writer) {
+func writeNamespaceMetaText(namespace string, w *bytes.Buffer) {
 	_, _ = writeBytes(w, metadataSection, space, namespaceToken, space, escapeASB(namespace))
 }
 
-func writeFirstMetaText(w io.Writer) {
+func writeFirstMetaText(w *bytes.Buffer) {
 	_, _ = writeBytes(w, metadataSection, space, tokenFirst)
 }
 
 // **** RECORD ****
 
-func recordToASB(c bool, r *models.Record, w io.Writer) (int, error) {
+func recordToASB(c bool, r *models.Record, w *bytes.Buffer) (int, error) {
 	var bytesWritten int
 
 	n, err := keyToASB(r.Key, w)
@@ -164,20 +163,28 @@ func recordToASB(c bool, r *models.Record, w io.Writer) (int, error) {
 	return bytesWritten, nil
 }
 
-func writeRecordHeaderGeneration(generation uint32, w io.Writer) (int, error) {
-	value := []byte(strconv.FormatUint(uint64(generation), 10))
+func writeRecordHeaderGeneration(generation uint32, w *bytes.Buffer) (int, error) {
+	var numBuf [20]byte
+	value := strconv.AppendUint(numBuf[:0], uint64(generation), 10)
+
 	return writeBytes(w, headerGeneration, value)
 }
 
-func writeRecordHeaderExpiration(expiration int64, w io.Writer) (int, error) {
-	return writeBytes(w, headerExpiration, []byte(strconv.FormatInt(expiration, 10)))
+func writeRecordHeaderExpiration(expiration int64, w *bytes.Buffer) (int, error) {
+	var numBuf [20]byte
+	value := strconv.AppendInt(numBuf[:0], expiration, 10)
+
+	return writeBytes(w, headerExpiration, value)
 }
 
-func writeRecordHeaderBinCount(binCount int, w io.Writer) (int, error) {
-	return writeBytes(w, headerBinCount, []byte(strconv.Itoa(binCount)))
+func writeRecordHeaderBinCount(binCount int, w *bytes.Buffer) (int, error) {
+	var numBuf [20]byte
+	value := strconv.AppendInt(numBuf[:0], int64(binCount), 10)
+
+	return writeBytes(w, headerBinCount, value)
 }
 
-func binsToASB(compact bool, bins a.BinMap, w io.Writer) (int, error) {
+func binsToASB(compact bool, bins a.BinMap, w *bytes.Buffer) (int, error) {
 	var bytesWritten int
 
 	// NOTE golang's random order map iteration
@@ -196,7 +203,7 @@ func binsToASB(compact bool, bins a.BinMap, w io.Writer) (int, error) {
 	return bytesWritten, nil
 }
 
-func binToASB(k string, c bool, v any, w io.Writer) (int, error) {
+func binToASB(k string, c bool, v any, w *bytes.Buffer) (int, error) {
 	var (
 		bytesWritten int
 		err          error
@@ -236,28 +243,36 @@ func binToASB(k string, c bool, v any, w io.Writer) (int, error) {
 	return bytesWritten, err
 }
 
-func writeBinBool(name string, v bool, w io.Writer) (int, error) {
-	return writeBytes(w, binBoolTypePrefix, escapeASB(name), space, boolToASB(v))
+func writeBinBool(name string, v bool, w *bytes.Buffer) (int, error) {
+	return writeEscapedNameValueLine(w, binBoolTypePrefix, name, boolToASB(v))
 }
 
 type binTypesInt interface {
 	int64 | int32 | int16 | int8 | int
 }
 
-func writeBinInt[T binTypesInt](name string, v T, w io.Writer) (int, error) {
-	value := []byte(strconv.FormatInt(int64(v), 10))
-	return writeBytes(w, binIntTypePrefix, escapeASB(name), space, value)
+func writeBinInt[T binTypesInt](name string, v T, w *bytes.Buffer) (int, error) {
+	var numBuf [20]byte
+	value := strconv.AppendInt(numBuf[:0], int64(v), 10)
+
+	return writeEscapedNameValueLine(w, binIntTypePrefix, name, value)
 }
 
-func writeBinFloat(name string, v float64, w io.Writer) (int, error) {
-	return writeBytes(w, binFloatTypePrefix, escapeASB(name), space, []byte(strconv.FormatFloat(v, 'g', -1, 64)))
+func writeBinFloat(name string, v float64, w *bytes.Buffer) (int, error) {
+	var numBuf [32]byte
+	value := strconv.AppendFloat(numBuf[:0], v, 'g', -1, 64)
+
+	return writeEscapedNameValueLine(w, binFloatTypePrefix, name, value)
 }
 
-func writeBinString(name, v string, w io.Writer) (int, error) {
-	return writeBytes(w, binStringTypePrefix, escapeASB(name), space, []byte(strconv.Itoa(len(v))), space, []byte(v))
+func writeBinString(name, v string, w *bytes.Buffer) (int, error) {
+	var numBuf [20]byte
+	valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
+
+	return writeEscapedNameLenStringLine(w, binStringTypePrefix, name, valueLen, v)
 }
 
-func writeBinBytes(name string, compact bool, v []byte, w io.Writer) (int, error) {
+func writeBinBytes(name string, compact bool, v []byte, w *bytes.Buffer) (int, error) {
 	var (
 		prefix  []byte
 		encoded []byte
@@ -268,18 +283,24 @@ func writeBinBytes(name string, compact bool, v []byte, w io.Writer) (int, error
 	switch compact {
 	case true:
 		prefix = binBytesTypeCompactPrefix
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(v))), space, v)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
 	case false:
 		prefix = binBytesTypePrefix
 		encoded = base64Encode(v)
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(encoded))), space, encoded)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
 		returnBase64Buffer(encoded)
 	}
 
 	return result, err
 }
 
-func writeBinHLL(name string, compact bool, v a.HLLValue, w io.Writer) (int, error) {
+func writeBinHLL(name string, compact bool, v a.HLLValue, w *bytes.Buffer) (int, error) {
 	var (
 		prefix  []byte
 		encoded []byte
@@ -290,26 +311,35 @@ func writeBinHLL(name string, compact bool, v a.HLLValue, w io.Writer) (int, err
 	switch compact {
 	case true:
 		prefix = binHLLTypeCompactPrefix
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(v))), space, v)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
 	case false:
 		prefix = binHLLTypePrefix
 		encoded = base64Encode(v)
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(encoded))), space, encoded)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
 		returnBase64Buffer(encoded)
 	}
 
 	return result, err
 }
 
-func writeBinGeoJSON(name string, v a.GeoJSONValue, w io.Writer) (int, error) {
-	return writeBytes(w, binGeoJSONTypePrefix, escapeASB(name), space, []byte(strconv.Itoa(len(v))), space, []byte(v))
+func writeBinGeoJSON(name string, v a.GeoJSONValue, w *bytes.Buffer) (int, error) {
+	var numBuf [20]byte
+	valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
+
+	return writeEscapedNameLenStringLine(w, binGeoJSONTypePrefix, name, valueLen, string(v))
 }
 
-func writeBinNil(name string, w io.Writer) (int, error) {
-	return writeBytes(w, binNilTypePrefix, escapeASB(name))
+func writeBinNil(name string, w *bytes.Buffer) (int, error) {
+	return writeEscapedNameOnlyLine(w, binNilTypePrefix, name)
 }
 
-func writeRawBlobBin(cdt *a.RawBlobValue, name string, compact bool, w io.Writer) (int, error) {
+func writeRawBlobBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buffer) (int, error) {
 	switch cdt.ParticleType {
 	case particleType.MAP:
 		return writeRawMapBin(cdt, name, compact, w)
@@ -320,7 +350,7 @@ func writeRawBlobBin(cdt *a.RawBlobValue, name string, compact bool, w io.Writer
 	}
 }
 
-func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w io.Writer) (int, error) {
+func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buffer) (int, error) {
 	var (
 		prefix  []byte
 		v       []byte
@@ -333,18 +363,24 @@ func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w io.Writer)
 	case true:
 		prefix = binMapTypeCompactPrefix
 		v = cdt.Data
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(v))), space, v)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
 	case false:
 		prefix = binMapTypePrefix
 		encoded = base64Encode(cdt.Data)
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(encoded))), space, encoded)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
 		returnBase64Buffer(encoded)
 	}
 
 	return result, err
 }
 
-func writeRawListBin(cdt *a.RawBlobValue, name string, compact bool, w io.Writer) (int, error) {
+func writeRawListBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buffer) (int, error) {
 	var (
 		prefix  []byte
 		v       []byte
@@ -357,11 +393,17 @@ func writeRawListBin(cdt *a.RawBlobValue, name string, compact bool, w io.Writer
 	case true:
 		prefix = binListTypeCompactPrefix
 		v = cdt.Data
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(v))), space, v)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
 	case false:
 		prefix = binListTypePrefix
 		encoded = base64Encode(cdt.Data)
-		result, err = writeBytes(w, prefix, escapeASB(name), space, []byte(strconv.Itoa(len(encoded))), space, encoded)
+
+		var numBuf [20]byte
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
+		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
 		returnBase64Buffer(encoded)
 	}
 
@@ -396,12 +438,12 @@ func boolToASB(b bool) []byte {
 	return falseBytes
 }
 
-func keyToASB(k *a.Key, w io.Writer) (int, error) {
+func keyToASB(k *a.Key, w *bytes.Buffer) (int, error) {
 	var bytesWritten int
 
 	userKey := k.Value()
 	if userKey != nil {
-		n, err := userKeyToASB(k.Value(), w)
+		n, err := userKeyToASB(userKey, w)
 		bytesWritten += n
 
 		if err != nil {
@@ -476,7 +518,21 @@ func returnBase64Buffer(buf []byte) {
 	base64BufferPool.Put(buf[:0])
 }
 
-func writeBytes(w io.Writer, data ...[]byte) (int, error) {
+func writeBytes(w *bytes.Buffer, data ...[]byte) (int, error) {
+	totalBytesWritten, err := writeRawBytes(w, data...)
+	if err != nil {
+		return totalBytesWritten, err
+	}
+
+	n, err := w.Write(newLine)
+	if err != nil {
+		return totalBytesWritten, err
+	}
+
+	return totalBytesWritten + n, nil
+}
+
+func writeRawBytes(w *bytes.Buffer, data ...[]byte) (int, error) {
 	totalBytesWritten := 0
 
 	for _, d := range data {
@@ -488,21 +544,14 @@ func writeBytes(w io.Writer, data ...[]byte) (int, error) {
 		totalBytesWritten += n
 	}
 
-	n, err := w.Write(newLine)
-	if err != nil {
-		return totalBytesWritten, err
-	}
-
-	totalBytesWritten += n
-
 	return totalBytesWritten, nil
 }
 
-func writeRecordNamespace(namespace string, w io.Writer) (int, error) {
-	return writeBytes(w, namespacePrefix, escapeASB(namespace))
+func writeRecordNamespace(namespace string, w *bytes.Buffer) (int, error) {
+	return writeEscapedValueLine(w, namespacePrefix, namespace)
 }
 
-func writeRecordDigest(digest []byte, w io.Writer) (int, error) {
+func writeRecordDigest(digest []byte, w *bytes.Buffer) (int, error) {
 	encoded := base64Encode(digest)
 	n, err := writeBytes(w, digestPrefix, encoded)
 	returnBase64Buffer(encoded)
@@ -510,11 +559,11 @@ func writeRecordDigest(digest []byte, w io.Writer) (int, error) {
 	return n, err
 }
 
-func writeRecordSet(setName string, w io.Writer) (int, error) {
-	return writeBytes(w, setPrefix, escapeASB(setName))
+func writeRecordSet(setName string, w *bytes.Buffer) (int, error) {
+	return writeEscapedValueLine(w, setPrefix, setName)
 }
 
-func userKeyToASB(userKey a.Value, w io.Writer) (int, error) {
+func userKeyToASB(userKey a.Value, w *bytes.Buffer) (int, error) {
 	switch v := userKey.GetObject().(type) {
 	// need the repeated int cases to satisfy the generic type checker
 	case int64:
@@ -544,7 +593,10 @@ type UserKeyTypesInt interface {
 	int64 | int32 | int16 | int8 | int
 }
 
-func writeUserKeyInt[T UserKeyTypesInt](v T, w io.Writer) (int, error) {
+func writeUserKeyInt[T UserKeyTypesInt](v T, w *bytes.Buffer) (int, error) {
+	var numBuf [20]byte
+	value := strconv.AppendInt(numBuf[:0], int64(v), 10)
+
 	return writeBytes(
 		w,
 		recordHeader,
@@ -553,11 +605,14 @@ func writeUserKeyInt[T UserKeyTypesInt](v T, w io.Writer) (int, error) {
 		space,
 		headerTypeInt,
 		space,
-		[]byte(strconv.FormatInt(int64(v), 10)),
+		value,
 	)
 }
 
-func writeUserKeyFloat(v float64, w io.Writer) (int, error) {
+func writeUserKeyFloat(v float64, w *bytes.Buffer) (int, error) {
+	var numBuf [32]byte
+	value := strconv.AppendFloat(numBuf[:0], v, 'f', -1, 64)
+
 	return writeBytes(
 		w,
 		recordHeader,
@@ -566,12 +621,15 @@ func writeUserKeyFloat(v float64, w io.Writer) (int, error) {
 		space,
 		headerTypeFloat,
 		space,
-		[]byte(strconv.FormatFloat(v, 'f', -1, 64)),
+		value,
 	)
 }
 
-func writeUserKeyString(v string, w io.Writer) (int, error) {
-	return writeBytes(
+func writeUserKeyString(v string, w *bytes.Buffer) (int, error) {
+	var lenBuf [20]byte
+	valueLen := strconv.AppendInt(lenBuf[:0], int64(len(v)), 10)
+
+	n, err := writeRawBytes(
 		w,
 		recordHeader,
 		space,
@@ -579,14 +637,31 @@ func writeUserKeyString(v string, w io.Writer) (int, error) {
 		space,
 		headerTypeString,
 		space,
-		[]byte(strconv.Itoa(len(v))),
+		valueLen,
 		space,
-		[]byte(v),
 	)
+	if err != nil {
+		return n, err
+	}
+
+	valueN, err := w.WriteString(v)
+
+	n += valueN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
+
+	return n, err
 }
 
-func writeUserKeyBytes(v []byte, w io.Writer) (int, error) {
+func writeUserKeyBytes(v []byte, w *bytes.Buffer) (int, error) {
 	encoded := base64Encode(v)
+
+	var lenBuf [20]byte
+	valueLen := strconv.AppendInt(lenBuf[:0], int64(len(encoded)), 10)
 	n, err := writeBytes(w,
 		recordHeader,
 		space,
@@ -594,7 +669,7 @@ func writeUserKeyBytes(v []byte, w io.Writer) (int, error) {
 		space,
 		headerTypeBytes,
 		space,
-		[]byte(strconv.Itoa(len(encoded))),
+		valueLen,
 		space,
 		encoded,
 	)
@@ -642,11 +717,176 @@ func escapeASB(s string) []byte {
 	return out
 }
 
-// **** SINDEX ****
-func sindexToASB(sindex *models.SIndex, w io.Writer) (int, error) {
-	// sindexes only ever use 1 path for now
-	numPaths := 1
+func writeEscapedValueLine(w *bytes.Buffer, prefix []byte, value string) (int, error) {
+	n, err := writeRawBytes(w, prefix)
+	if err != nil {
+		return n, err
+	}
 
+	valueN, err := writeEscapedASBToWriter(w, value)
+
+	n += valueN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
+
+	return n, err
+}
+
+func writeEscapedNameOnlyLine(w *bytes.Buffer, prefix []byte, name string) (int, error) {
+	n, err := writeRawBytes(w, prefix)
+	if err != nil {
+		return n, err
+	}
+
+	nameN, err := writeEscapedASBToWriter(w, name)
+
+	n += nameN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
+
+	return n, err
+}
+
+func writeEscapedNameValueLine(w *bytes.Buffer, prefix []byte, name string, value []byte) (int, error) {
+	n, err := writeRawBytes(w, prefix)
+	if err != nil {
+		return n, err
+	}
+
+	nameN, err := writeEscapedASBToWriter(w, name)
+
+	n += nameN
+	if err != nil {
+		return n, err
+	}
+
+	valueN, err := writeRawBytes(w, space, value)
+
+	n += valueN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
+
+	return n, err
+}
+
+func writeEscapedNameLenValueLine(w *bytes.Buffer, prefix []byte, name string, valueLen, value []byte) (int, error) {
+	n, err := writeRawBytes(w, prefix)
+	if err != nil {
+		return n, err
+	}
+
+	nameN, err := writeEscapedASBToWriter(w, name)
+
+	n += nameN
+	if err != nil {
+		return n, err
+	}
+
+	valueN, err := writeRawBytes(w, space, valueLen, space, value)
+
+	n += valueN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
+
+	return n, err
+}
+
+func writeEscapedNameLenStringLine(
+	w *bytes.Buffer,
+	prefix []byte,
+	name string,
+	valueLen []byte,
+	value string,
+) (int, error) {
+	n, err := writeRawBytes(w, prefix)
+	if err != nil {
+		return n, err
+	}
+
+	nameN, err := writeEscapedASBToWriter(w, name)
+
+	n += nameN
+	if err != nil {
+		return n, err
+	}
+
+	valueN, err := writeRawBytes(w, space, valueLen, space)
+
+	n += valueN
+	if err != nil {
+		return n, err
+	}
+
+	valueN, err = w.WriteString(value)
+
+	n += valueN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
+
+	return n, err
+}
+
+func writeEscapedASBToWriter(w *bytes.Buffer, s string) (int, error) {
+	total := 0
+	start := 0
+
+	for i := 0; i < len(s); i++ {
+		if !needsEscape[s[i]] {
+			continue
+		}
+
+		n, err := w.WriteString(s[start:i])
+
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		n, err = 1, w.WriteByte('\\')
+
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		n, err = 1, w.WriteByte(s[i])
+
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		start = i + 1
+	}
+
+	n, err := w.WriteString(s[start:])
+	total += n
+
+	return total, err
+}
+
+// **** SINDEX ****
+func sindexToASB(sindex *models.SIndex, w *bytes.Buffer) (int, error) {
 	sindexSection := globalSIndex
 	// If we have sindex with expression, we need to use the globalSIndexExpression section.
 	if sindex.Expression != "" {
@@ -667,7 +907,7 @@ func sindexToASB(sindex *models.SIndex, w io.Writer) (int, error) {
 		space,
 		{byte(sindex.IndexType)},
 		space,
-		[]byte(strconv.Itoa(numPaths)),
+		[]byte("1"),
 		space,
 		escapeASB(sindex.Path.BinName),
 		space,
@@ -690,7 +930,10 @@ func sindexToASB(sindex *models.SIndex, w io.Writer) (int, error) {
 
 // **** UDFs ****
 
-func udfToASB(udf *models.UDF, w io.Writer) (int, error) {
+func udfToASB(udf *models.UDF, w *bytes.Buffer) (int, error) {
+	var lenBuf [20]byte
+	contentLen := strconv.AppendInt(lenBuf[:0], int64(len(udf.Content)), 10)
+
 	return writeBytes(
 		w,
 		globalSection,
@@ -701,7 +944,7 @@ func udfToASB(udf *models.UDF, w io.Writer) (int, error) {
 		space,
 		escapeASB(udf.Name),
 		space,
-		[]byte(strconv.Itoa(len(udf.Content))),
+		contentLen,
 		space,
 		udf.Content,
 	)

--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -203,44 +203,37 @@ func binsToASB(compact bool, bins a.BinMap, w *bytes.Buffer) (int, error) {
 	return bytesWritten, nil
 }
 
-func binToASB(k string, c bool, v any, w *bytes.Buffer) (int, error) {
-	var (
-		bytesWritten int
-		err          error
-	)
-
+func binToASB(k string, compact bool, v any, w *bytes.Buffer) (int, error) {
 	switch v := v.(type) {
 	case bool:
-		bytesWritten, err = writeBinBool(k, v, w)
+		return writeBinBool(k, v, w)
 	case int64:
-		bytesWritten, err = writeBinInt(k, v, w)
+		return writeBinInt(k, v, w)
 	case int32:
-		bytesWritten, err = writeBinInt(k, v, w)
+		return writeBinInt(k, v, w)
 	case int16:
-		bytesWritten, err = writeBinInt(k, v, w)
+		return writeBinInt(k, v, w)
 	case int8:
-		bytesWritten, err = writeBinInt(k, v, w)
+		return writeBinInt(k, v, w)
 	case int:
-		bytesWritten, err = writeBinInt(k, v, w)
+		return writeBinInt(k, v, w)
 	case float64:
-		bytesWritten, err = writeBinFloat(k, v, w)
+		return writeBinFloat(k, v, w)
 	case string:
-		bytesWritten, err = writeBinString(k, v, w)
+		return writeBinString(k, v, w)
 	case []byte:
-		bytesWritten, err = writeBinBytes(k, c, v, w)
+		return writeBinBytes(k, compact, v, w)
 	case *a.RawBlobValue:
-		bytesWritten, err = writeRawBlobBin(v, k, c, w)
+		return writeRawBlobBin(v, k, compact, w)
 	case a.HLLValue:
-		bytesWritten, err = writeBinHLL(k, c, v, w)
+		return writeBinHLL(k, compact, v, w)
 	case a.GeoJSONValue:
-		bytesWritten, err = writeBinGeoJSON(k, v, w)
+		return writeBinGeoJSON(k, v, w)
 	case nil:
-		bytesWritten, err = writeBinNil(k, w)
-	default:
-		return bytesWritten, fmt.Errorf("unknown bin type: %T, key: %s", v, k)
+		return writeBinNil(k, w)
 	}
 
-	return bytesWritten, err
+	return 0, fmt.Errorf("unknown bin type: %T, key: %s", v, k)
 }
 
 func writeBinBool(name string, v bool, w *bytes.Buffer) (int, error) {
@@ -285,28 +278,15 @@ func writeBinBytes(name string, compact bool, v []byte, w *bytes.Buffer) (int, e
 }
 
 func writeBinHLL(name string, compact bool, v a.HLLValue, w *bytes.Buffer) (int, error) {
-	var (
-		prefix []byte
-		result int
-		err    error
-	)
-
-	switch compact {
-	case true:
-		prefix = binHLLTypeCompactPrefix
-
+	if compact {
 		var numBuf [20]byte
 		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
-	case false:
-		prefix = binHLLTypePrefix
-
-		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
-		result, err = writeEscapedNameLenBase64Line(w, prefix, name, valueLen, v)
+		return writeEscapedNameLenValueLine(w, binHLLTypeCompactPrefix, name, valueLen, v)
 	}
 
-	return result, err
+	var numBuf [20]byte
+	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
+	return writeEscapedNameLenBase64Line(w, binHLLTypePrefix, name, valueLen, v)
 }
 
 func writeBinGeoJSON(name string, v a.GeoJSONValue, w *bytes.Buffer) (int, error) {
@@ -332,57 +312,27 @@ func writeRawBlobBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Bu
 }
 
 func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buffer) (int, error) {
-	var (
-		prefix []byte
-		v      []byte
-		result int
-		err    error
-	)
-
-	switch compact {
-	case true:
-		prefix = binMapTypeCompactPrefix
-		v = cdt.Data
-
+	if compact {
 		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
-	case false:
-		prefix = binMapTypePrefix
-
-		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
-		result, err = writeEscapedNameLenBase64Line(w, prefix, name, valueLen, cdt.Data)
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(cdt.Data)), 10)
+		return writeEscapedNameLenValueLine(w, binMapTypeCompactPrefix, name, valueLen, cdt.Data)
 	}
 
-	return result, err
+	var numBuf [20]byte
+	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
+	return writeEscapedNameLenBase64Line(w, binMapTypePrefix, name, valueLen, cdt.Data)
 }
 
 func writeRawListBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buffer) (int, error) {
-	var (
-		prefix []byte
-		v      []byte
-		result int
-		err    error
-	)
-
-	switch compact {
-	case true:
-		prefix = binListTypeCompactPrefix
-		v = cdt.Data
-
+	if compact {
 		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
-	case false:
-		prefix = binListTypePrefix
-
-		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
-		result, err = writeEscapedNameLenBase64Line(w, prefix, name, valueLen, cdt.Data)
+		valueLen := strconv.AppendInt(numBuf[:0], int64(len(cdt.Data)), 10)
+		return writeEscapedNameLenValueLine(w, binListTypeCompactPrefix, name, valueLen, cdt.Data)
 	}
 
-	return result, err
+	var numBuf [20]byte
+	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
+	return writeEscapedNameLenBase64Line(w, binListTypePrefix, name, valueLen, cdt.Data)
 }
 
 func blobBinToASB(val []byte, bytesType byte, name string) []byte {

--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -273,39 +273,22 @@ func writeBinString(name, v string, w *bytes.Buffer) (int, error) {
 }
 
 func writeBinBytes(name string, compact bool, v []byte, w *bytes.Buffer) (int, error) {
-	var (
-		prefix  []byte
-		encoded []byte
-		result  int
-		err     error
-	)
 
-	switch compact {
-	case true:
-		prefix = binBytesTypeCompactPrefix
-
-		var numBuf [20]byte
+	var numBuf [20]byte
+	if compact {
 		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
-	case false:
-		prefix = binBytesTypePrefix
-		encoded = base64Encode(v)
-
-		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
-		returnBase64Buffer(encoded)
+		return writeEscapedNameLenValueLine(w, binBytesTypeCompactPrefix, name, valueLen, v)
 	}
 
-	return result, err
+	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
+	return writeEscapedNameLenBase64Line(w, binBytesTypePrefix, name, valueLen, v)
 }
 
 func writeBinHLL(name string, compact bool, v a.HLLValue, w *bytes.Buffer) (int, error) {
 	var (
-		prefix  []byte
-		encoded []byte
-		result  int
-		err     error
+		prefix []byte
+		result int
+		err    error
 	)
 
 	switch compact {
@@ -317,12 +300,10 @@ func writeBinHLL(name string, compact bool, v a.HLLValue, w *bytes.Buffer) (int,
 		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
 	case false:
 		prefix = binHLLTypePrefix
-		encoded = base64Encode(v)
 
 		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
-		returnBase64Buffer(encoded)
+		valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
+		result, err = writeEscapedNameLenBase64Line(w, prefix, name, valueLen, v)
 	}
 
 	return result, err
@@ -352,11 +333,10 @@ func writeRawBlobBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Bu
 
 func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buffer) (int, error) {
 	var (
-		prefix  []byte
-		v       []byte
-		encoded []byte
-		result  int
-		err     error
+		prefix []byte
+		v      []byte
+		result int
+		err    error
 	)
 
 	switch compact {
@@ -369,12 +349,10 @@ func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buf
 		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
 	case false:
 		prefix = binMapTypePrefix
-		encoded = base64Encode(cdt.Data)
 
 		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
-		returnBase64Buffer(encoded)
+		valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
+		result, err = writeEscapedNameLenBase64Line(w, prefix, name, valueLen, cdt.Data)
 	}
 
 	return result, err
@@ -382,11 +360,10 @@ func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buf
 
 func writeRawListBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buffer) (int, error) {
 	var (
-		prefix  []byte
-		v       []byte
-		encoded []byte
-		result  int
-		err     error
+		prefix []byte
+		v      []byte
+		result int
+		err    error
 	)
 
 	switch compact {
@@ -399,12 +376,10 @@ func writeRawListBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Bu
 		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, v)
 	case false:
 		prefix = binListTypePrefix
-		encoded = base64Encode(cdt.Data)
 
 		var numBuf [20]byte
-		valueLen := strconv.AppendInt(numBuf[:0], int64(len(encoded)), 10)
-		result, err = writeEscapedNameLenValueLine(w, prefix, name, valueLen, encoded)
-		returnBase64Buffer(encoded)
+		valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
+		result, err = writeEscapedNameLenBase64Line(w, prefix, name, valueLen, cdt.Data)
 	}
 
 	return result, err
@@ -552,9 +527,19 @@ func writeRecordNamespace(namespace string, w *bytes.Buffer) (int, error) {
 }
 
 func writeRecordDigest(digest []byte, w *bytes.Buffer) (int, error) {
-	encoded := base64Encode(digest)
-	n, err := writeBytes(w, digestPrefix, encoded)
-	returnBase64Buffer(encoded)
+	n, err := writeRawBytes(w, digestPrefix)
+	if err != nil {
+		return n, err
+	}
+
+	encodedN, err := writeBase64ToBuffer(w, digest)
+	n += encodedN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
 
 	return n, err
 }
@@ -658,11 +643,9 @@ func writeUserKeyString(v string, w *bytes.Buffer) (int, error) {
 }
 
 func writeUserKeyBytes(v []byte, w *bytes.Buffer) (int, error) {
-	encoded := base64Encode(v)
-
 	var lenBuf [20]byte
-	valueLen := strconv.AppendInt(lenBuf[:0], int64(len(encoded)), 10)
-	n, err := writeBytes(w,
+	valueLen := strconv.AppendInt(lenBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
+	n, err := writeRawBytes(w,
 		recordHeader,
 		space,
 		recordHeaderType,
@@ -671,10 +654,19 @@ func writeUserKeyBytes(v []byte, w *bytes.Buffer) (int, error) {
 		space,
 		valueLen,
 		space,
-		encoded,
 	)
+	if err != nil {
+		return n, err
+	}
 
-	returnBase64Buffer(encoded)
+	encodedN, err := writeBase64ToBuffer(w, v)
+	n += encodedN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
 
 	return n, err
 }
@@ -805,6 +797,54 @@ func writeEscapedNameLenValueLine(w *bytes.Buffer, prefix []byte, name string, v
 	n += newLineN
 
 	return n, err
+}
+
+func writeEscapedNameLenBase64Line(
+	w *bytes.Buffer,
+	prefix []byte,
+	name string,
+	valueLen []byte,
+	value []byte,
+) (int, error) {
+	n, err := writeRawBytes(w, prefix)
+	if err != nil {
+		return n, err
+	}
+
+	nameN, err := writeEscapedASBToWriter(w, name)
+
+	n += nameN
+	if err != nil {
+		return n, err
+	}
+
+	valueN, err := writeRawBytes(w, space, valueLen, space)
+
+	n += valueN
+	if err != nil {
+		return n, err
+	}
+
+	encodedN, err := writeBase64ToBuffer(w, value)
+	n += encodedN
+	if err != nil {
+		return n, err
+	}
+
+	newLineN, err := w.Write(newLine)
+	n += newLineN
+
+	return n, err
+}
+
+func writeBase64ToBuffer(w *bytes.Buffer, data []byte) (int, error) {
+	encodedLen := base64.StdEncoding.EncodedLen(len(data))
+	w.Grow(encodedLen)
+	dst := w.AvailableBuffer()
+	dst = dst[:encodedLen]
+	base64.StdEncoding.Encode(dst, data)
+
+	return w.Write(dst)
 }
 
 func writeEscapedNameLenStringLine(

--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -36,8 +36,6 @@ type Encoder[T models.TokenConstraint] struct {
 
 	firstFileWritten atomic.Bool
 	id               atomic.Int64
-
-	estimatedRecordSize atomic.Uint32
 }
 
 // NewEncoder creates a new Encoder.
@@ -52,12 +50,11 @@ func (e *Encoder[T]) GenerateFilename(prefix, suffix string) string {
 	return prefix + e.config.Namespace + "_" + strconv.FormatInt(e.id.Add(1), 10) + suffix + ".asb"
 }
 
-// EncodeToken encodes a token to the ASB format.
-// It returns a byte slice of the encoded token and an error if the encoding fails.
-func (e *Encoder[T]) EncodeToken(token T) ([]byte, error) {
+// EncodeToken encodes a token to the ASB format, writing to the provided writer.
+func (e *Encoder[T]) EncodeToken(token T, w io.Writer) error {
 	t, ok := any(token).(*models.Token)
 	if !ok {
-		return nil, fmt.Errorf("unsupported token type %T for ASB encoder", token)
+		return fmt.Errorf("unsupported token type %T for ASB encoder", token)
 	}
 
 	var (
@@ -65,16 +62,13 @@ func (e *Encoder[T]) EncodeToken(token T) ([]byte, error) {
 		err error
 	)
 
-	allocationSize := int(e.estimatedRecordSize.Load() * 11 / 10) // add 10% to be safe
-	buff := bytes.NewBuffer(make([]byte, 0, allocationSize))
-
 	switch t.Type {
 	case models.TokenTypeRecord:
-		n, err = e.encodeRecord(t.Record, buff)
+		n, err = recordToASB(e.config.Compact, t.Record, w)
 	case models.TokenTypeUDF:
-		n, err = e.encodeUDF(t.UDF, buff)
+		n, err = udfToASB(t.UDF, w)
 	case models.TokenTypeSIndex:
-		n, err = e.encodeSIndex(t.SIndex, buff)
+		n, err = sindexToASB(t.SIndex, w)
 	case models.TokenTypeInvalid:
 		n, err = 0, errors.New("invalid token")
 	default:
@@ -82,25 +76,10 @@ func (e *Encoder[T]) EncodeToken(token T) ([]byte, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode token at byte %d: %w", n, err)
+		return fmt.Errorf("failed to encode token at byte %d: %w", n, err)
 	}
 
-	// keep smoothed last value
-	e.estimatedRecordSize.Store((e.estimatedRecordSize.Load() + uint32(n)) / 2)
-
-	return buff.Bytes(), nil
-}
-
-func (e *Encoder[T]) encodeRecord(rec *models.Record, buff *bytes.Buffer) (int, error) {
-	return recordToASB(e.config.Compact, rec, buff)
-}
-
-func (e *Encoder[T]) encodeUDF(udf *models.UDF, buff *bytes.Buffer) (int, error) {
-	return udfToASB(udf, buff)
-}
-
-func (e *Encoder[T]) encodeSIndex(sIndex *models.SIndex, buff *bytes.Buffer) (int, error) {
-	return sindexToASB(sIndex, buff)
+	return nil
 }
 
 // GetHeader returns the header of the ASB file as a byte slice.

--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -549,6 +549,22 @@ func writeRecordSet(setName string, w *bytes.Buffer) (int, error) {
 }
 
 func userKeyToASB(userKey a.Value, w *bytes.Buffer) (int, error) {
+	switch v := userKey.(type) {
+	case a.IntegerValue:
+		return writeUserKeyInt(int(v), w)
+	case a.LongValue:
+		return writeUserKeyInt(int64(v), w)
+	case a.FloatValue:
+		return writeUserKeyFloat(float64(v), w)
+	case a.StringValue:
+		return writeUserKeyString(string(v), w)
+	case a.BytesValue:
+		return writeUserKeyBytes([]byte(v), w)
+	case a.NullValue:
+		return 0, nil
+	}
+
+	// Fallback for custom Value implementations and compatibility with non-standard key values.
 	switch v := userKey.GetObject().(type) {
 	// need the repeated int cases to satisfy the generic type checker
 	case int64:

--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -266,7 +266,6 @@ func writeBinString(name, v string, w *bytes.Buffer) (int, error) {
 }
 
 func writeBinBytes(name string, compact bool, v []byte, w *bytes.Buffer) (int, error) {
-
 	var numBuf [20]byte
 	if compact {
 		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
@@ -274,6 +273,7 @@ func writeBinBytes(name string, compact bool, v []byte, w *bytes.Buffer) (int, e
 	}
 
 	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
+
 	return writeEscapedNameLenBase64Line(w, binBytesTypePrefix, name, valueLen, v)
 }
 
@@ -281,11 +281,13 @@ func writeBinHLL(name string, compact bool, v a.HLLValue, w *bytes.Buffer) (int,
 	if compact {
 		var numBuf [20]byte
 		valueLen := strconv.AppendInt(numBuf[:0], int64(len(v)), 10)
+
 		return writeEscapedNameLenValueLine(w, binHLLTypeCompactPrefix, name, valueLen, v)
 	}
 
 	var numBuf [20]byte
 	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
+
 	return writeEscapedNameLenBase64Line(w, binHLLTypePrefix, name, valueLen, v)
 }
 
@@ -315,11 +317,13 @@ func writeRawMapBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Buf
 	if compact {
 		var numBuf [20]byte
 		valueLen := strconv.AppendInt(numBuf[:0], int64(len(cdt.Data)), 10)
+
 		return writeEscapedNameLenValueLine(w, binMapTypeCompactPrefix, name, valueLen, cdt.Data)
 	}
 
 	var numBuf [20]byte
 	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
+
 	return writeEscapedNameLenBase64Line(w, binMapTypePrefix, name, valueLen, cdt.Data)
 }
 
@@ -327,11 +331,13 @@ func writeRawListBin(cdt *a.RawBlobValue, name string, compact bool, w *bytes.Bu
 	if compact {
 		var numBuf [20]byte
 		valueLen := strconv.AppendInt(numBuf[:0], int64(len(cdt.Data)), 10)
+
 		return writeEscapedNameLenValueLine(w, binListTypeCompactPrefix, name, valueLen, cdt.Data)
 	}
 
 	var numBuf [20]byte
 	valueLen := strconv.AppendInt(numBuf[:0], int64(base64.StdEncoding.EncodedLen(len(cdt.Data))), 10)
+
 	return writeEscapedNameLenBase64Line(w, binListTypePrefix, name, valueLen, cdt.Data)
 }
 
@@ -483,6 +489,7 @@ func writeRecordDigest(digest []byte, w *bytes.Buffer) (int, error) {
 	}
 
 	encodedN, err := writeBase64ToBuffer(w, digest)
+
 	n += encodedN
 	if err != nil {
 		return n, err
@@ -611,6 +618,7 @@ func writeUserKeyString(v string, w *bytes.Buffer) (int, error) {
 func writeUserKeyBytes(v []byte, w *bytes.Buffer) (int, error) {
 	var lenBuf [20]byte
 	valueLen := strconv.AppendInt(lenBuf[:0], int64(base64.StdEncoding.EncodedLen(len(v))), 10)
+
 	n, err := writeRawBytes(w,
 		recordHeader,
 		space,
@@ -626,6 +634,7 @@ func writeUserKeyBytes(v []byte, w *bytes.Buffer) (int, error) {
 	}
 
 	encodedN, err := writeBase64ToBuffer(w, v)
+
 	n += encodedN
 	if err != nil {
 		return n, err
@@ -792,6 +801,7 @@ func writeEscapedNameLenBase64Line(
 	}
 
 	encodedN, err := writeBase64ToBuffer(w, value)
+
 	n += encodedN
 	if err != nil {
 		return n, err

--- a/io/encoding/asb/encode.go
+++ b/io/encoding/asb/encode.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 	"sync/atomic"
 
 	a "github.com/aerospike/aerospike-client-go/v8"
@@ -408,47 +407,6 @@ func keyToASB(k *a.Key, w *bytes.Buffer) (int, error) {
 	return bytesWritten, nil
 }
 
-// base64BufferPool is a pool of byte slices used for base64 encoding
-var base64BufferPool = sync.Pool{
-	New: func() any {
-		// The buffer size is arbitrary and will be grown if needed
-		return make([]byte, 0, 1024)
-	},
-}
-
-// base64Encode encodes the input bytes using base64 encoding.
-// It returns a slice that references a pooled buffer, which must be returned to the pool
-// after use by calling returnBase64Buffer.
-func base64Encode(v []byte) []byte {
-	encodedLen := base64.StdEncoding.EncodedLen(len(v))
-
-	// Get a buffer from the pool
-	buf := base64BufferPool.Get().([]byte)
-
-	// Ensure the buffer is large enough
-	if cap(buf) < encodedLen {
-		// If the buffer is too small, create a new one with sufficient capacity
-		buf = make([]byte, encodedLen)
-	} else {
-		// Otherwise, resize the existing buffer
-		buf = buf[:encodedLen]
-	}
-
-	// Encode the data
-	base64.StdEncoding.Encode(buf, v)
-
-	// Return a slice that references the pooled buffer
-	return buf
-}
-
-// returnBase64Buffer returns the buffer to the pool.
-// This must be called after the buffer returned by base64Encode is no longer needed.
-func returnBase64Buffer(buf []byte) {
-	// Reset length but keep capacity
-	//nolint:staticcheck // We try to decrease allocation, not to make them zero.
-	base64BufferPool.Put(buf[:0])
-}
-
 func writeBytes(w *bytes.Buffer, data ...[]byte) (int, error) {
 	totalBytesWritten, err := writeRawBytes(w, data...)
 	if err != nil {
@@ -516,7 +474,7 @@ func userKeyToASB(userKey a.Value, w *bytes.Buffer) (int, error) {
 	case a.StringValue:
 		return writeUserKeyString(string(v), w)
 	case a.BytesValue:
-		return writeUserKeyBytes([]byte(v), w)
+		return writeUserKeyBytes(v, w)
 	case a.NullValue:
 		return 0, nil
 	}

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
+	"io"
 	mRand "math/rand/v2"
 	"reflect"
 	"sort"
@@ -56,13 +57,15 @@ func TestEncodeTokenRecord(t *testing.T) {
 	}
 
 	buff := &bytes.Buffer{}
-	_, err := encoder.encodeRecord(token.Record, buff)
+	var w io.Writer = buff
+	_, err := recordToASB(encoder.config.Compact, token.Record, w)
 	require.NoError(t, err)
 	expected := bytes.Clone(buff.Bytes())
 
-	actual, err := encoder.EncodeToken(token)
+	actual := &bytes.Buffer{}
+	err = encoder.EncodeToken(token, actual)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Equal(t, expected, actual.Bytes())
 }
 
 func TestEncodeTokenUDF(t *testing.T) {
@@ -79,13 +82,15 @@ func TestEncodeTokenUDF(t *testing.T) {
 		},
 	}
 	buff := &bytes.Buffer{}
-	_, err := encoder.encodeUDF(token.UDF, buff)
+	var w io.Writer = buff
+	_, err := udfToASB(token.UDF, w)
 	require.NoError(t, err)
 	expected := buff.Bytes()
 
-	actual, err := encoder.EncodeToken(token)
+	actual := &bytes.Buffer{}
+	err = encoder.EncodeToken(token, actual)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Equal(t, expected, actual.Bytes())
 }
 
 func TestEncodeTokenSIndex(t *testing.T) {
@@ -107,13 +112,15 @@ func TestEncodeTokenSIndex(t *testing.T) {
 	}
 
 	buff := &bytes.Buffer{}
-	_, err := encoder.encodeSIndex(token.SIndex, buff)
+	var w io.Writer = buff
+	_, err := sindexToASB(token.SIndex, w)
 	require.NoError(t, err)
 	expected := buff.Bytes()
 
-	actual, err := encoder.EncodeToken(token)
+	actual := &bytes.Buffer{}
+	err = encoder.EncodeToken(token, actual)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	require.Equal(t, expected, actual.Bytes())
 }
 
 func TestEncodeTokenInvalid(t *testing.T) {
@@ -126,9 +133,9 @@ func TestEncodeTokenInvalid(t *testing.T) {
 	}
 
 	token.Type = models.TokenTypeInvalid
-	actual, err := encoder.EncodeToken(token)
+	actual := &bytes.Buffer{}
+	err := encoder.EncodeToken(token, actual)
 	require.Error(t, err)
-	require.Nil(t, actual)
 }
 
 func TestEncodeRecord(t *testing.T) {
@@ -154,7 +161,8 @@ func TestEncodeRecord(t *testing.T) {
 	expected := fmt.Sprintf(recTemplate, base64Encode(key.Digest()), recExpr)
 
 	buff := &bytes.Buffer{}
-	n, err := encoder.encodeRecord(rec, buff)
+	var w io.Writer = buff
+	n, err := recordToASB(encoder.config.Compact, rec, w)
 	require.NoError(t, err)
 	actual := buff.Bytes()
 	require.Equal(t, len(actual), n)
@@ -163,8 +171,6 @@ func TestEncodeRecord(t *testing.T) {
 
 func TestEncodeSIndex(t *testing.T) {
 	t.Parallel()
-
-	encoder := NewEncoder[*models.Token](testEncoderConfig)
 
 	sindex := &models.SIndex{
 		Namespace: "ns",
@@ -178,7 +184,8 @@ func TestEncodeSIndex(t *testing.T) {
 
 	expected := []byte("* i ns  name N 1 bin S\n")
 	buff := &bytes.Buffer{}
-	n, err := encoder.encodeSIndex(sindex, buff)
+	var w io.Writer = buff
+	n, err := sindexToASB(sindex, w)
 	require.Len(t, expected, n)
 	require.NoError(t, err)
 	require.Equal(t, expected, buff.Bytes())
@@ -1648,7 +1655,8 @@ func BenchmarkEncodeRecord(b *testing.B) {
 
 	for b.Loop() {
 		buff := &bytes.Buffer{}
-		_, _ = encoder.encodeRecord(rec, buff)
+		var w io.Writer = buff
+		_, _ = recordToASB(encoder.config.Compact, rec, w)
 		output.Write(buff.Bytes())
 	}
 }

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -297,6 +297,25 @@ func Test__SIndexToASB(t *testing.T) {
 			want:  len("* i ns set name N 1 bin S context\n"),
 			wantW: "* i ns set name N 1 bin S context\n",
 		},
+		{
+			name: "positive sindex with expression",
+			args: args{
+				sindex: &models.SIndex{
+					Namespace: "ns",
+					Name:      "name",
+					Set:       "set",
+					IndexType: models.BinSIndex,
+					Path: models.SIndexPath{
+						BinName:    "bin",
+						BinType:    models.StringSIDataType,
+						B64Context: "context",
+					},
+					Expression: "expr",
+				},
+			},
+			want:  len("* e ns set name N 1 bin S context expr\n"),
+			wantW: "* e ns set name N 1 bin S context expr\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -367,6 +386,22 @@ func Test_binToASB(t *testing.T) {
 			args: args{
 				k: "binName",
 				v: int64(-123),
+			},
+			want: []byte("- I binName -123\n"),
+		},
+		{
+			name: "positive int32 bin",
+			args: args{
+				k: "binName",
+				v: int32(123),
+			},
+			want: []byte("- I binName 123\n"),
+		},
+		{
+			name: "positive int16 bin",
+			args: args{
+				k: "binName",
+				v: int16(-123),
 			},
 			want: []byte("- I binName -123\n"),
 		},
@@ -1116,8 +1151,9 @@ func Test_writeBinString(t *testing.T) {
 func Test_writeBinBytes(t *testing.T) {
 	t.Parallel()
 	type args struct {
-		name string
-		v    []byte
+		compact bool
+		name    string
+		v       []byte
 	}
 	tests := []struct {
 		name    string
@@ -1129,8 +1165,9 @@ func Test_writeBinBytes(t *testing.T) {
 		{
 			name: "positive simple",
 			args: args{
-				name: "binName",
-				v:    []byte("hello"),
+				compact: false,
+				name:    "binName",
+				v:       []byte("hello"),
 			},
 			want: len(fmt.Sprintf("- B binName %d %s\n",
 				len(base64Encode([]byte("hello"))), base64Encode([]byte("hello")))),
@@ -1140,20 +1177,31 @@ func Test_writeBinBytes(t *testing.T) {
 		{
 			name: "positive escaped",
 			args: args{
-				name: "b\nin\\Nam e",
-				v:    []byte("hello"),
+				compact: false,
+				name:    "b\nin\\Nam e",
+				v:       []byte("hello"),
 			},
 			want: len(fmt.Sprintf("- B b\\\nin\\\\Nam\\ e %d %s\n",
 				len(base64Encode([]byte("hello"))), base64Encode([]byte("hello")))),
 			wantW: fmt.Sprintf("- B b\\\nin\\\\Nam\\ e %d %s\n",
 				len(base64Encode([]byte("hello"))), base64Encode([]byte("hello"))),
 		},
+		{
+			name: "positive compact simple",
+			args: args{
+				compact: true,
+				name:    "binName",
+				v:       []byte("hello"),
+			},
+			want:  len("- B! binName 5 hello\n"),
+			wantW: "- B! binName 5 hello\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			w := &bytes.Buffer{}
-			got, err := writeBinBytes(tt.args.name, false, tt.args.v, w)
+			got, err := writeBinBytes(tt.args.name, tt.args.compact, tt.args.v, w)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("writeBinBytes() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1171,8 +1219,9 @@ func Test_writeBinBytes(t *testing.T) {
 func Test_writeBinHLL(t *testing.T) {
 	t.Parallel()
 	type args struct {
-		name string
-		v    a.HLLValue
+		compact bool
+		name    string
+		v       a.HLLValue
 	}
 	tests := []struct {
 		name    string
@@ -1184,8 +1233,9 @@ func Test_writeBinHLL(t *testing.T) {
 		{
 			name: "positive simple",
 			args: args{
-				name: "binName",
-				v:    a.HLLValue("hello"),
+				compact: false,
+				name:    "binName",
+				v:       a.HLLValue("hello"),
 			},
 			want: len(fmt.Sprintf("- Y binName %d %s\n",
 				len(base64Encode(a.HLLValue("hello"))), base64Encode(a.HLLValue("hello")))),
@@ -1195,20 +1245,31 @@ func Test_writeBinHLL(t *testing.T) {
 		{
 			name: "positive escaped",
 			args: args{
-				name: "b\nin\\Nam e",
-				v:    a.HLLValue("hello"),
+				compact: false,
+				name:    "b\nin\\Nam e",
+				v:       a.HLLValue("hello"),
 			},
 			want: len(fmt.Sprintf("- Y b\\\nin\\\\Nam\\ e %d %s\n",
 				len(base64Encode(a.HLLValue("hello"))), base64Encode(a.HLLValue("hello")))),
 			wantW: fmt.Sprintf("- Y b\\\nin\\\\Nam\\ e %d %s\n",
 				len(base64Encode(a.HLLValue("hello"))), base64Encode(a.HLLValue("hello"))),
 		},
+		{
+			name: "positive compact simple",
+			args: args{
+				compact: true,
+				name:    "binName",
+				v:       a.HLLValue("hello"),
+			},
+			want:  len("- Y! binName 5 hello\n"),
+			wantW: "- Y! binName 5 hello\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			w := &bytes.Buffer{}
-			got, err := writeBinHLL(tt.args.name, false, tt.args.v, w)
+			got, err := writeBinHLL(tt.args.name, tt.args.compact, tt.args.v, w)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("writeBinHLL() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1947,8 +2008,9 @@ func Test_writeRawListBin(t *testing.T) {
 	data := []byte("hello")
 	b64Data := base64.StdEncoding.EncodeToString(data)
 	type args struct {
-		cdt  *a.RawBlobValue
-		name string
+		compact bool
+		cdt     *a.RawBlobValue
+		name    string
 	}
 	tests := []struct {
 		args    args
@@ -1960,6 +2022,7 @@ func Test_writeRawListBin(t *testing.T) {
 		{
 			name: "positive simple",
 			args: args{
+				compact: false,
 				cdt: &a.RawBlobValue{
 					Data: data,
 				},
@@ -1971,6 +2034,7 @@ func Test_writeRawListBin(t *testing.T) {
 		{
 			name: "positive escaped bin name",
 			args: args{
+				compact: false,
 				cdt: &a.RawBlobValue{
 					Data: data,
 				},
@@ -1979,12 +2043,24 @@ func Test_writeRawListBin(t *testing.T) {
 			want:  len(fmt.Sprintf("- L %s %d %s\n", "b\\ in\\\\Name\\\n", len(b64Data), b64Data)),
 			wantW: fmt.Sprintf("- L %s %d %s\n", "b\\ in\\\\Name\\\n", len(b64Data), b64Data),
 		},
+		{
+			name: "positive compact simple",
+			args: args{
+				compact: true,
+				cdt: &a.RawBlobValue{
+					Data: data,
+				},
+				name: "binName",
+			},
+			want:  len("- L! binName 5 hello\n"),
+			wantW: "- L! binName 5 hello\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			w := &bytes.Buffer{}
-			got, err := writeRawListBin(tt.args.cdt, tt.args.name, false, w)
+			got, err := writeRawListBin(tt.args.cdt, tt.args.name, tt.args.compact, w)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("writeRawListBin() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -2004,8 +2080,9 @@ func Test_writeRawMapBin(t *testing.T) {
 	data := []byte("hello")
 	b64Data := base64.StdEncoding.EncodeToString(data)
 	type args struct {
-		cdt  *a.RawBlobValue
-		name string
+		compact bool
+		cdt     *a.RawBlobValue
+		name    string
 	}
 	tests := []struct {
 		args    args
@@ -2017,6 +2094,7 @@ func Test_writeRawMapBin(t *testing.T) {
 		{
 			name: "positive simple",
 			args: args{
+				compact: false,
 				cdt: &a.RawBlobValue{
 					Data: data,
 				},
@@ -2028,6 +2106,7 @@ func Test_writeRawMapBin(t *testing.T) {
 		{
 			name: "positive escaped bin name",
 			args: args{
+				compact: false,
 				cdt: &a.RawBlobValue{
 					Data: data,
 				},
@@ -2036,12 +2115,24 @@ func Test_writeRawMapBin(t *testing.T) {
 			want:  len(fmt.Sprintf("- M %s %d %s\n", "b\\ in\\\\Name\\\n", len(b64Data), b64Data)),
 			wantW: fmt.Sprintf("- M %s %d %s\n", "b\\ in\\\\Name\\\n", len(b64Data), b64Data),
 		},
+		{
+			name: "positive compact simple",
+			args: args{
+				compact: true,
+				cdt: &a.RawBlobValue{
+					Data: data,
+				},
+				name: "binName",
+			},
+			want:  len("- M! binName 5 hello\n"),
+			wantW: "- M! binName 5 hello\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			w := &bytes.Buffer{}
-			got, err := writeRawMapBin(tt.args.cdt, tt.args.name, false, w)
+			got, err := writeRawMapBin(tt.args.cdt, tt.args.name, tt.args.compact, w)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("writeRawMapBin() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
-	"io"
 	mRand "math/rand/v2"
 	"reflect"
 	"sort"
@@ -57,8 +56,7 @@ func TestEncodeTokenRecord(t *testing.T) {
 	}
 
 	buff := &bytes.Buffer{}
-	var w io.Writer = buff
-	_, err := recordToASB(encoder.config.Compact, token.Record, w)
+	_, err := recordToASB(encoder.config.Compact, token.Record, buff)
 	require.NoError(t, err)
 	expected := bytes.Clone(buff.Bytes())
 
@@ -82,8 +80,7 @@ func TestEncodeTokenUDF(t *testing.T) {
 		},
 	}
 	buff := &bytes.Buffer{}
-	var w io.Writer = buff
-	_, err := udfToASB(token.UDF, w)
+	_, err := udfToASB(token.UDF, buff)
 	require.NoError(t, err)
 	expected := buff.Bytes()
 
@@ -112,8 +109,7 @@ func TestEncodeTokenSIndex(t *testing.T) {
 	}
 
 	buff := &bytes.Buffer{}
-	var w io.Writer = buff
-	_, err := sindexToASB(token.SIndex, w)
+	_, err := sindexToASB(token.SIndex, buff)
 	require.NoError(t, err)
 	expected := buff.Bytes()
 
@@ -161,8 +157,7 @@ func TestEncodeRecord(t *testing.T) {
 	expected := fmt.Sprintf(recTemplate, base64Encode(key.Digest()), recExpr)
 
 	buff := &bytes.Buffer{}
-	var w io.Writer = buff
-	n, err := recordToASB(encoder.config.Compact, rec, w)
+	n, err := recordToASB(encoder.config.Compact, rec, buff)
 	require.NoError(t, err)
 	actual := buff.Bytes()
 	require.Equal(t, len(actual), n)
@@ -184,8 +179,7 @@ func TestEncodeSIndex(t *testing.T) {
 
 	expected := []byte("* i ns  name N 1 bin S\n")
 	buff := &bytes.Buffer{}
-	var w io.Writer = buff
-	n, err := sindexToASB(sindex, w)
+	n, err := sindexToASB(sindex, buff)
 	require.Len(t, expected, n)
 	require.NoError(t, err)
 	require.Equal(t, expected, buff.Bytes())
@@ -1655,8 +1649,7 @@ func BenchmarkEncodeRecord(b *testing.B) {
 
 	for b.Loop() {
 		buff := &bytes.Buffer{}
-		var w io.Writer = buff
-		_, _ = recordToASB(encoder.config.Compact, rec, w)
+		_, _ = recordToASB(encoder.config.Compact, rec, buff)
 		output.Write(buff.Bytes())
 	}
 }

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -1688,30 +1688,52 @@ func Test_writeUserKeyBytes(t *testing.T) {
 }
 
 func BenchmarkEncodeRecord(b *testing.B) {
-	output := &bytes.Buffer{}
 	encoder := NewEncoder[*models.Token](testEncoderConfig)
 
 	key := genKey()
+
 	rec := &models.Record{
 		Record: &a.Record{
 			Key: key,
 			Bins: a.BinMap{
-				"IntBin":     1,
-				"FloatBin":   1.1,
-				"StringBin":  "string",
-				"BoolBin":    true,
-				"BlobBin":    []byte("bytes"),
-				"GeoJSONBin": a.GeoJSONValue(`{"type": "Polygon", "coordinates": [[[0,0], [0, 10], [10, 10], [10, 0], [0,0]]]}`),
+				// Scalar Types
+				"IntBin":    123456789,
+				"FloatBin":  98.6,
+				"StringBin": "This is a longer string to test buffer allocation",
+				"BoolBin":   true,
+				"NilBin":    nil,
+
+				// Bytes/Blobs
+				"SmallBlob": []byte("small"),
+				"LargeBlob": bytes.Repeat([]byte("A"), 1024), // 1KB blob
+
+				// Geospatial
+				"GeoJSONBin": a.GeoJSONValue(`{"type": "Point", "coordinates": [12.49, 41.89]}`),
+
+				// Raw CDT payloads accepted by ASB encoder.
+				"MapBin": &a.RawBlobValue{
+					ParticleType: particleType.MAP,
+					Data:         []byte{0x81, 0xA2, 'i', 'd', 0x2A}, // msgpack-ish payload
+				},
+				"ListBin": &a.RawBlobValue{
+					ParticleType: particleType.LIST,
+					Data:         []byte{0x93, 0x01, 0x02, 0x03}, // msgpack-ish payload
+				},
 			},
-			Generation: 1234,
+			Generation: 5,
 		},
-		VoidTime: 10,
+		VoidTime: 3600, // 1 hour TTL
 	}
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	buff := &bytes.Buffer{}
 	for b.Loop() {
-		buff := &bytes.Buffer{}
-		_, _ = recordToASB(encoder.config.Compact, rec, buff)
-		output.Write(buff.Bytes())
+		buff.Reset()
+		if _, err := recordToASB(encoder.config.Compact, rec, buff); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/io/encoding/asb/encode_test.go
+++ b/io/encoding/asb/encode_test.go
@@ -1654,6 +1654,65 @@ func BenchmarkEncodeRecord(b *testing.B) {
 	}
 }
 
+func BenchmarkEncodeTokenRecordAllDataTypes(b *testing.B) {
+	encoder := NewEncoder[*models.Token](testEncoderConfig)
+
+	key, err := a.NewKey("test", "all_types_set", "benchmark-user-key")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	token := &models.Token{
+		Type: models.TokenTypeRecord,
+		Record: &models.Record{
+			Record: &a.Record{
+				Key: key,
+				Bins: a.BinMap{
+					"bool_true":   true,
+					"bool_false":  false,
+					"int64_bin":   int64(922337203685477580),
+					"int32_bin":   int32(214748364),
+					"int16_bin":   int16(32000),
+					"int8_bin":    int8(120),
+					"int_bin":     123456789,
+					"float64_bin": 123456.789123,
+					"string_bin":  "text with spaces and symbols !@#$%^&*()",
+					"bytes_bin":   []byte("raw-byte-payload-123"),
+					"hll_bin":     a.HLLValue("hll-bytes"),
+					"geojson_bin": a.GeoJSONValue(`{"type":"Point","coordinates":[12.34,56.78]}`),
+					"nil_bin":     nil,
+					"raw_map_bin": &a.RawBlobValue{
+						ParticleType: particleType.MAP,
+						Data:         []byte("raw-map-bytes"),
+					},
+					"raw_list_bin": &a.RawBlobValue{
+						ParticleType: particleType.LIST,
+						Data:         []byte("raw-list-bytes"),
+					},
+				},
+				Generation: 42,
+			},
+			VoidTime: 1712345678,
+		},
+	}
+
+	out := bytes.NewBuffer(make([]byte, 0, 4096))
+	if err := encoder.EncodeToken(token, out); err != nil {
+		b.Fatal(err)
+	}
+
+	b.SetBytes(int64(out.Len()))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		out.Reset()
+		if err := encoder.EncodeToken(token, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // base64EncodeNative old encoding mechanism, using a default library.
 // Left here for benchmarking purposes.
 func base64EncodeNative(v []byte) []byte {

--- a/io/encoding/asbx/encode.go
+++ b/io/encoding/asbx/encode.go
@@ -15,8 +15,8 @@
 package asbx
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"sync/atomic"
 
 	"github.com/aerospike/backup-go/models"
@@ -53,7 +53,7 @@ func (e *Encoder[T]) GenerateFilename(prefix, suffix string) string {
 }
 
 // EncodeToken encodes a token to the ASBX format, writing to the provided writer.
-func (e *Encoder[T]) EncodeToken(token T, w io.Writer) error {
+func (e *Encoder[T]) EncodeToken(token T, w *bytes.Buffer) error {
 	t, ok := any(token).(*models.ASBXToken)
 	if !ok {
 		return fmt.Errorf("unsupported token type %T for ASBX encoder", token)

--- a/io/encoding/asbx/encode.go
+++ b/io/encoding/asbx/encode.go
@@ -16,6 +16,7 @@ package asbx
 
 import (
 	"fmt"
+	"io"
 	"sync/atomic"
 
 	"github.com/aerospike/backup-go/models"
@@ -51,13 +52,11 @@ func (e *Encoder[T]) GenerateFilename(prefix, suffix string) string {
 	return fmt.Sprintf("%s%s_%d%s.asbx", prefix, e.namespace, e.fileNumber.Add(1), suffix)
 }
 
-// EncodeToken encodes a token to the ASBX format.
-// It returns a byte slice of the encoded token and an error if the encoding
-// fails.
-func (e *Encoder[T]) EncodeToken(token T) ([]byte, error) {
+// EncodeToken encodes a token to the ASBX format, writing to the provided writer.
+func (e *Encoder[T]) EncodeToken(token T, w io.Writer) error {
 	t, ok := any(token).(*models.ASBXToken)
 	if !ok {
-		return nil, fmt.Errorf("unsupported token type %T for ASBX encoder", token)
+		return fmt.Errorf("unsupported token type %T for ASBX encoder", token)
 	}
 	// Message contains:
 	// Digest - 20 bytes.
@@ -65,22 +64,31 @@ func (e *Encoder[T]) EncodeToken(token T) ([]byte, error) {
 	// Payload - contains a raw message from tcp protocol.
 	pLen := len(t.Payload)
 
-	msg := make([]byte, 26+pLen)
+	// Write digest (20 bytes).
+	if _, err := w.Write(t.Key.Digest()); err != nil {
+		return err
+	}
 
-	copy(msg[:20], t.Key.Digest())
+	// Write payload length (6 bytes, big-endian).
+	lenBuf := [6]byte{
+		byte(pLen >> 40),
+		byte(pLen >> 32),
+		byte(pLen >> 24),
+		byte(pLen >> 16),
+		byte(pLen >> 8),
+		byte(pLen),
+	}
 
-	// Fill payload len.
-	msg[20] = byte(pLen >> 40)
-	msg[21] = byte(pLen >> 32)
-	msg[22] = byte(pLen >> 24)
-	msg[23] = byte(pLen >> 16)
-	msg[24] = byte(pLen >> 8)
-	msg[25] = byte(pLen)
+	if _, err := w.Write(lenBuf[:]); err != nil {
+		return err
+	}
 
-	// Fill token.
-	copy(msg[26:], t.Payload)
+	// Write payload.
+	if _, err := w.Write(t.Payload); err != nil {
+		return err
+	}
 
-	return msg, nil
+	return nil
 }
 
 // GetHeader returns prepared file header as []byte.

--- a/io/encoding/asbx/encode_decode_test.go
+++ b/io/encoding/asbx/encode_decode_test.go
@@ -72,9 +72,10 @@ func TestEncoder_Decoder(t *testing.T) {
 	h := enc.GetHeader(num, false)
 	content = append(content, h...)
 
-	et, err := enc.EncodeToken(token)
+	tokenBuf := &bytes.Buffer{}
+	err = enc.EncodeToken(token, tokenBuf)
 	require.NoError(t, err)
-	content = append(content, et...)
+	content = append(content, tokenBuf.Bytes()...)
 
 	// Decode.
 	reader := bytes.NewReader(content)

--- a/io_encoding.go
+++ b/io_encoding.go
@@ -37,7 +37,7 @@ const (
 //
 //go:generate mockery --name Encoder
 type Encoder[T models.TokenConstraint] interface {
-	EncodeToken(T) ([]byte, error)
+	EncodeToken(T, io.Writer) error
 	GetHeader(uint64, bool) []byte
 	GenerateFilename(prefix, suffix string) string
 }

--- a/io_encoding.go
+++ b/io_encoding.go
@@ -15,6 +15,7 @@
 package backup
 
 import (
+	"bytes"
 	"io"
 	"log/slog"
 
@@ -37,7 +38,7 @@ const (
 //
 //go:generate mockery --name Encoder
 type Encoder[T models.TokenConstraint] interface {
-	EncodeToken(T, io.Writer) error
+	EncodeToken(T, *bytes.Buffer) error
 	GetHeader(uint64, bool) []byte
 	GenerateFilename(prefix, suffix string) string
 }

--- a/mocks/Encoder_mock.go
+++ b/mocks/Encoder_mock.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"io"
+
 	"github.com/aerospike/backup-go/models"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,31 +39,20 @@ func (_m *MockEncoder[T]) EXPECT() *MockEncoder_Expecter[T] {
 }
 
 // EncodeToken provides a mock function for the type MockEncoder
-func (_mock *MockEncoder[T]) EncodeToken(v T) ([]byte, error) {
-	ret := _mock.Called(v)
+func (_mock *MockEncoder[T]) EncodeToken(v T, writer io.Writer) error {
+	ret := _mock.Called(v, writer)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EncodeToken")
 	}
 
-	var r0 []byte
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(T) ([]byte, error)); ok {
-		return returnFunc(v)
-	}
-	if returnFunc, ok := ret.Get(0).(func(T) []byte); ok {
-		r0 = returnFunc(v)
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(T, io.Writer) error); ok {
+		r0 = returnFunc(v, writer)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
-		}
+		r0 = ret.Error(0)
 	}
-	if returnFunc, ok := ret.Get(1).(func(T) error); ok {
-		r1 = returnFunc(v)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
+	return r0
 }
 
 // MockEncoder_EncodeToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EncodeToken'
@@ -71,29 +62,35 @@ type MockEncoder_EncodeToken_Call[T models.TokenConstraint] struct {
 
 // EncodeToken is a helper method to define mock.On call
 //   - v T
-func (_e *MockEncoder_Expecter[T]) EncodeToken(v interface{}) *MockEncoder_EncodeToken_Call[T] {
-	return &MockEncoder_EncodeToken_Call[T]{Call: _e.mock.On("EncodeToken", v)}
+//   - writer io.Writer
+func (_e *MockEncoder_Expecter[T]) EncodeToken(v interface{}, writer interface{}) *MockEncoder_EncodeToken_Call[T] {
+	return &MockEncoder_EncodeToken_Call[T]{Call: _e.mock.On("EncodeToken", v, writer)}
 }
 
-func (_c *MockEncoder_EncodeToken_Call[T]) Run(run func(v T)) *MockEncoder_EncodeToken_Call[T] {
+func (_c *MockEncoder_EncodeToken_Call[T]) Run(run func(v T, writer io.Writer)) *MockEncoder_EncodeToken_Call[T] {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 T
 		if args[0] != nil {
 			arg0 = args[0].(T)
 		}
+		var arg1 io.Writer
+		if args[1] != nil {
+			arg1 = args[1].(io.Writer)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
 }
 
-func (_c *MockEncoder_EncodeToken_Call[T]) Return(bytes []byte, err error) *MockEncoder_EncodeToken_Call[T] {
-	_c.Call.Return(bytes, err)
+func (_c *MockEncoder_EncodeToken_Call[T]) Return(err error) *MockEncoder_EncodeToken_Call[T] {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockEncoder_EncodeToken_Call[T]) RunAndReturn(run func(v T) ([]byte, error)) *MockEncoder_EncodeToken_Call[T] {
+func (_c *MockEncoder_EncodeToken_Call[T]) RunAndReturn(run func(v T, writer io.Writer) error) *MockEncoder_EncodeToken_Call[T] {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/Encoder_mock.go
+++ b/mocks/Encoder_mock.go
@@ -39,8 +39,8 @@ func (_m *MockEncoder[T]) EXPECT() *MockEncoder_Expecter[T] {
 }
 
 // EncodeToken provides a mock function for the type MockEncoder
-func (_mock *MockEncoder[T]) EncodeToken(v T, writer *bytes.Buffer) error {
-	ret := _mock.Called(v, writer)
+func (_mock *MockEncoder[T]) EncodeToken(v T, buffer *bytes.Buffer) error {
+	ret := _mock.Called(v, buffer)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EncodeToken")
@@ -48,7 +48,7 @@ func (_mock *MockEncoder[T]) EncodeToken(v T, writer *bytes.Buffer) error {
 
 	var r0 error
 	if returnFunc, ok := ret.Get(0).(func(T, *bytes.Buffer) error); ok {
-		r0 = returnFunc(v, writer)
+		r0 = returnFunc(v, buffer)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -62,12 +62,12 @@ type MockEncoder_EncodeToken_Call[T models.TokenConstraint] struct {
 
 // EncodeToken is a helper method to define mock.On call
 //   - v T
-//   - writer *bytes.Buffer
-func (_e *MockEncoder_Expecter[T]) EncodeToken(v interface{}, writer interface{}) *MockEncoder_EncodeToken_Call[T] {
-	return &MockEncoder_EncodeToken_Call[T]{Call: _e.mock.On("EncodeToken", v, writer)}
+//   - buffer *bytes.Buffer
+func (_e *MockEncoder_Expecter[T]) EncodeToken(v interface{}, buffer interface{}) *MockEncoder_EncodeToken_Call[T] {
+	return &MockEncoder_EncodeToken_Call[T]{Call: _e.mock.On("EncodeToken", v, buffer)}
 }
 
-func (_c *MockEncoder_EncodeToken_Call[T]) Run(run func(v T, writer *bytes.Buffer)) *MockEncoder_EncodeToken_Call[T] {
+func (_c *MockEncoder_EncodeToken_Call[T]) Run(run func(v T, buffer *bytes.Buffer)) *MockEncoder_EncodeToken_Call[T] {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 T
 		if args[0] != nil {
@@ -90,7 +90,7 @@ func (_c *MockEncoder_EncodeToken_Call[T]) Return(err error) *MockEncoder_Encode
 	return _c
 }
 
-func (_c *MockEncoder_EncodeToken_Call[T]) RunAndReturn(run func(v T, writer *bytes.Buffer) error) *MockEncoder_EncodeToken_Call[T] {
+func (_c *MockEncoder_EncodeToken_Call[T]) RunAndReturn(run func(v T, buffer *bytes.Buffer) error) *MockEncoder_EncodeToken_Call[T] {
 	_c.Call.Return(run)
 	return _c
 }
@@ -201,8 +201,8 @@ func (_c *MockEncoder_GetHeader_Call[T]) Run(run func(v uint64, b bool)) *MockEn
 	return _c
 }
 
-func (_c *MockEncoder_GetHeader_Call[T]) Return(bytes []byte) *MockEncoder_GetHeader_Call[T] {
-	_c.Call.Return(bytes)
+func (_c *MockEncoder_GetHeader_Call[T]) Return(bytes1 []byte) *MockEncoder_GetHeader_Call[T] {
+	_c.Call.Return(bytes1)
 	return _c
 }
 

--- a/mocks/Encoder_mock.go
+++ b/mocks/Encoder_mock.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	"io"
+	"bytes"
 
 	"github.com/aerospike/backup-go/models"
 	mock "github.com/stretchr/testify/mock"
@@ -39,7 +39,7 @@ func (_m *MockEncoder[T]) EXPECT() *MockEncoder_Expecter[T] {
 }
 
 // EncodeToken provides a mock function for the type MockEncoder
-func (_mock *MockEncoder[T]) EncodeToken(v T, writer io.Writer) error {
+func (_mock *MockEncoder[T]) EncodeToken(v T, writer *bytes.Buffer) error {
 	ret := _mock.Called(v, writer)
 
 	if len(ret) == 0 {
@@ -47,7 +47,7 @@ func (_mock *MockEncoder[T]) EncodeToken(v T, writer io.Writer) error {
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(T, io.Writer) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(T, *bytes.Buffer) error); ok {
 		r0 = returnFunc(v, writer)
 	} else {
 		r0 = ret.Error(0)
@@ -62,20 +62,20 @@ type MockEncoder_EncodeToken_Call[T models.TokenConstraint] struct {
 
 // EncodeToken is a helper method to define mock.On call
 //   - v T
-//   - writer io.Writer
+//   - writer *bytes.Buffer
 func (_e *MockEncoder_Expecter[T]) EncodeToken(v interface{}, writer interface{}) *MockEncoder_EncodeToken_Call[T] {
 	return &MockEncoder_EncodeToken_Call[T]{Call: _e.mock.On("EncodeToken", v, writer)}
 }
 
-func (_c *MockEncoder_EncodeToken_Call[T]) Run(run func(v T, writer io.Writer)) *MockEncoder_EncodeToken_Call[T] {
+func (_c *MockEncoder_EncodeToken_Call[T]) Run(run func(v T, writer *bytes.Buffer)) *MockEncoder_EncodeToken_Call[T] {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 T
 		if args[0] != nil {
 			arg0 = args[0].(T)
 		}
-		var arg1 io.Writer
+		var arg1 *bytes.Buffer
 		if args[1] != nil {
-			arg1 = args[1].(io.Writer)
+			arg1 = args[1].(*bytes.Buffer)
 		}
 		run(
 			arg0,
@@ -90,7 +90,7 @@ func (_c *MockEncoder_EncodeToken_Call[T]) Return(err error) *MockEncoder_Encode
 	return _c
 }
 
-func (_c *MockEncoder_EncodeToken_Call[T]) RunAndReturn(run func(v T, writer io.Writer) error) *MockEncoder_EncodeToken_Call[T] {
+func (_c *MockEncoder_EncodeToken_Call[T]) RunAndReturn(run func(v T, writer *bytes.Buffer) error) *MockEncoder_EncodeToken_Call[T] {
 	_c.Call.Return(run)
 	return _c
 }

--- a/token_writers.go
+++ b/token_writers.go
@@ -15,6 +15,7 @@
 package backup
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -92,6 +93,7 @@ type tokenWriter[T models.TokenConstraint] struct {
 	output    io.WriteCloser
 	logger    *slog.Logger
 	stateInfo *stateInfo
+	buf       bytes.Buffer
 }
 
 type stateInfo struct {
@@ -129,8 +131,9 @@ func newTokenWriter[T models.TokenConstraint](
 
 // Write encodes v and writes it to the output.
 func (w *tokenWriter[T]) Write(v T) (int, error) {
-	data, err := w.encoder.EncodeToken(v)
-	if err != nil {
+	w.buf.Reset()
+
+	if err := w.encoder.EncodeToken(v, &w.buf); err != nil {
 		return 0, fmt.Errorf("failed to encode token: %w", err)
 	}
 
@@ -144,7 +147,7 @@ func (w *tokenWriter[T]) Write(v T) (int, error) {
 		}
 	}
 
-	return w.output.Write(data)
+	return w.output.Write(w.buf.Bytes())
 }
 
 // Close releases resources associated with the tokenWriter and ensures the underlying writer is properly closed.

--- a/token_writers_test.go
+++ b/token_writers_test.go
@@ -76,16 +76,16 @@ func TestTokenWriter(t *testing.T) {
 	invalidToken := &models.Token{Type: models.TokenTypeInvalid}
 
 	mockEncoder := mocks.NewMockEncoder[*models.Token](t)
-	mockEncoder.EXPECT().EncodeToken(recToken, mock.Anything).RunAndReturn(func(_ *models.Token, w io.Writer) error {
-		_, _ = w.Write([]byte("encoded rec "))
+	mockEncoder.EXPECT().EncodeToken(recToken, mock.Anything).RunAndReturn(func(_ *models.Token, w *bytes.Buffer) error {
+		_, _ = w.WriteString("encoded rec ")
 		return nil
 	})
-	mockEncoder.EXPECT().EncodeToken(SIndexToken, mock.Anything).RunAndReturn(func(_ *models.Token, w io.Writer) error {
-		_, _ = w.Write([]byte("encoded sindex "))
+	mockEncoder.EXPECT().EncodeToken(SIndexToken, mock.Anything).RunAndReturn(func(_ *models.Token, w *bytes.Buffer) error {
+		_, _ = w.WriteString("encoded sindex ")
 		return nil
 	})
-	mockEncoder.EXPECT().EncodeToken(UDFToken, mock.Anything).RunAndReturn(func(_ *models.Token, w io.Writer) error {
-		_, _ = w.Write([]byte("encoded UDF "))
+	mockEncoder.EXPECT().EncodeToken(UDFToken, mock.Anything).RunAndReturn(func(_ *models.Token, w *bytes.Buffer) error {
+		_, _ = w.WriteString("encoded UDF ")
 		return nil
 	})
 	mockEncoder.EXPECT().EncodeToken(invalidToken, mock.Anything).Return(errors.New("error"))

--- a/token_writers_test.go
+++ b/token_writers_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aerospike/backup-go/mocks"
 	"github.com/aerospike/backup-go/models"
 	pipemocks "github.com/aerospike/backup-go/pipe/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,10 +76,19 @@ func TestTokenWriter(t *testing.T) {
 	invalidToken := &models.Token{Type: models.TokenTypeInvalid}
 
 	mockEncoder := mocks.NewMockEncoder[*models.Token](t)
-	mockEncoder.EXPECT().EncodeToken(recToken).Return([]byte("encoded rec "), nil)
-	mockEncoder.EXPECT().EncodeToken(SIndexToken).Return([]byte("encoded sindex "), nil)
-	mockEncoder.EXPECT().EncodeToken(UDFToken).Return([]byte("encoded UDF "), nil)
-	mockEncoder.EXPECT().EncodeToken(invalidToken).Return(nil, errors.New("error"))
+	mockEncoder.EXPECT().EncodeToken(recToken, mock.Anything).RunAndReturn(func(_ *models.Token, w io.Writer) error {
+		_, _ = w.Write([]byte("encoded rec "))
+		return nil
+	})
+	mockEncoder.EXPECT().EncodeToken(SIndexToken, mock.Anything).RunAndReturn(func(_ *models.Token, w io.Writer) error {
+		_, _ = w.Write([]byte("encoded sindex "))
+		return nil
+	})
+	mockEncoder.EXPECT().EncodeToken(UDFToken, mock.Anything).RunAndReturn(func(_ *models.Token, w io.Writer) error {
+		_, _ = w.Write([]byte("encoded UDF "))
+		return nil
+	})
+	mockEncoder.EXPECT().EncodeToken(invalidToken, mock.Anything).Return(errors.New("error"))
 
 	b := bytes.Buffer{}
 	dst := newBufferWriteCloser(&b)
@@ -105,7 +115,7 @@ func TestTokenWriter(t *testing.T) {
 		Record: &a.Record{},
 	}
 	failRecToken := models.NewRecordToken(failRec, 0, nil)
-	mockEncoder.EXPECT().EncodeToken(failRecToken).Return(nil, errors.New("error"))
+	mockEncoder.EXPECT().EncodeToken(failRecToken, mock.Anything).Return(errors.New("error"))
 	_, err = writer.Write(failRecToken)
 	require.Error(t, err)
 


### PR DESCRIPTION
Impact: Slight memory improvement.

Analysis: This approach consistently shaved about 30–40 MB off the peak memory compared to the Baseline (dropping from ~1.08 GB to ~1.04 GB).

Cursor:
  1. API change `EncodeToken(T) ([]byte, error)` → `EncodeToken(T, io.Writer) error` - Good. Pushing the writer down lets callers control allocation. The
     caller decides whether to use a pooled buffer, pre-allocated buffer, or write directly.
  2. Removing `estimatedRecordSize` heuristic in ASB encoder - Fine. The smoothed size estimation was a micro-optimization that added complexity. If you're
     reusing buffers at the caller level, this doesn't help much anyway.
  3. Removing wrapper methods `encodeRecord`, `encodeUDF`, `encodeSIndex` - Good cleanup. They were just pass-throughs adding indirection.
