### PR TITLE
Fieldalign token struct

### DIFF
--- a/models/token.go
+++ b/models/token.go
@@ -40,11 +40,11 @@ type Token struct {
 	SIndex *SIndex
 	UDF    *UDF
 	Record *Record
-	Type   TokenType
-	Size   uint64
 	// Filter represents serialized partition filter for page, that record belongs to.
 	// Is used only on pagination read, to save reading states.
 	Filter *PartitionFilterSerialized
+	Size   uint64
+	Type   TokenType
 }
 
 func (t *Token) GetSize() uint64 {


### PR DESCRIPTION
Fieldalign says: 16 bytes saved: struct with 48 pointer bytes could be 32

No measurable improvement, but let's keep it just for piece in mind. We use token a lot.