### PR TITLE
BKRS-359 Decouple backup package from io/storage/local

### DIFF
--- a/io/storage/aws/s3/writer_test.go
+++ b/io/storage/aws/s3/writer_test.go
@@ -377,6 +377,9 @@ func TestNewWriter_Success(t *testing.T) {
 	assert.NotNil(t, writer)
 	assert.Equal(t, testBucket, writer.bucketName)
 	assert.Equal(t, testDir, writer.prefix)
+	// S3 uploads files as a limited number of chunks, so the file limit
+	// validation must be applied to it.
+	assert.False(t, writer.GetOptions().NoChunkLimit)
 }
 
 // TestNewWriter_NoPath tests error when no path provided

--- a/io/storage/local/writer.go
+++ b/io/storage/local/writer.go
@@ -54,6 +54,9 @@ func NewWriter(ctx context.Context, opts ...options.Opt) (*Writer, error) {
 		w.ChunkSize = defaultBufferSize
 	}
 
+	// The local file system doesn't split files into a limited number of chunks.
+	w.NoChunkLimit = true
+
 	// Special case for null target: writes are intentionally no-op.
 	if filepath.Clean(w.PathList[0]) == filepath.Clean(os.DevNull) {
 		return w, nil

--- a/io/storage/local/writer_test.go
+++ b/io/storage/local/writer_test.go
@@ -80,6 +80,18 @@ func TestDirectoryWriter_GetType(t *testing.T) {
 	require.Equal(t, TypeLocal, w.GetType())
 }
 
+func TestDirectoryWriter_GetOptions_NoChunkLimit(t *testing.T) {
+	t.Parallel()
+	tmpDir := path.Join(t.TempDir(), "TestDirectoryWriter_GetOptions_NoChunkLimit")
+	ctx := t.Context()
+	w, err := NewWriter(ctx, options.WithDir(tmpDir))
+	require.NoError(t, err)
+
+	// The local file system has no chunk count restriction, so the file limit
+	// validation must be skipped for it.
+	require.True(t, w.GetOptions().NoChunkLimit)
+}
+
 func TestNewWriter_NoPath(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/io/storage/options/options.go
+++ b/io/storage/options/options.go
@@ -78,6 +78,13 @@ type Options struct {
 
 	// WithChecksum enables checksum validation on upload.
 	WithChecksum bool
+
+	// NoChunkLimit indicates that the storage doesn't upload files as a limited number
+	// of chunks (e.g. a local file system or stdout), so the maximum chunk count
+	// restriction doesn't apply to it.
+	// It describes a capability of the storage backend and is set by the Writer
+	// implementation itself, not by the user.
+	NoChunkLimit bool
 }
 
 type Opt func(*Options)

--- a/io/storage/std/writer.go
+++ b/io/storage/std/writer.go
@@ -90,5 +90,8 @@ func (w *Writer) GetType() string {
 
 // GetOptions returns initialized options for the writer.
 func (w *Writer) GetOptions() options.Options {
-	return options.Options{}
+	return options.Options{
+		// Stdout doesn't split files into a limited number of chunks.
+		NoChunkLimit: true,
+	}
 }

--- a/io/storage/std/writer_test.go
+++ b/io/storage/std/writer_test.go
@@ -379,3 +379,16 @@ func TestStdout_GetType(t *testing.T) {
 	res := w.GetType()
 	require.Equal(t, stdoutType, res)
 }
+
+func TestStdout_GetOptions_NoChunkLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	w, err := NewWriter(ctx, defaultBufferSize)
+	require.NoError(t, err)
+
+	// Stdout has no chunk count restriction, so the file limit validation
+	// must be skipped for it.
+	require.True(t, w.GetOptions().NoChunkLimit)
+}

--- a/shared.go
+++ b/shared.go
@@ -20,7 +20,6 @@ import (
 	"runtime/debug"
 
 	a "github.com/aerospike/aerospike-client-go/v8"
-	"github.com/aerospike/backup-go/io/storage/local"
 	"github.com/segmentio/asm/base64"
 )
 
@@ -82,13 +81,20 @@ func newKeyByDigest(namespace, digest string) (*a.Key, error) {
 // validateFileLimit checks if the file limit can be processed within the maximum allowed number of chunks.
 // Returns an error if the chunk size is zero or if the required chunks exceed the predefined maximum.
 func validateFileLimit(fileLimit uint64, w Writer) error {
-	// Skip validation if file limit is zero, or writer is not configured or writer is local.
-	if fileLimit == 0 || w == nil || w.GetType() == local.TypeLocal {
+	// Skip validation if file limit is zero, or writer is not configured.
+	if fileLimit == 0 || w == nil {
+		return nil
+	}
+
+	opts := w.GetOptions()
+
+	// Skip validation for storages that don't split files into a limited number of chunks.
+	if opts.NoChunkLimit {
 		return nil
 	}
 
 	// Get chunk size from configured writer.
-	chunkSize := w.GetOptions().ChunkSize
+	chunkSize := opts.ChunkSize
 
 	// Double check chunk size. Not to divide by zero.
 	if chunkSize <= 0 {

--- a/shared_test.go
+++ b/shared_test.go
@@ -18,7 +18,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/aerospike/backup-go/io/storage/local"
 	"github.com/aerospike/backup-go/io/storage/options"
 	"github.com/aerospike/backup-go/mocks"
 	"github.com/stretchr/testify/require"
@@ -53,22 +52,33 @@ func TestValidateFileLimit(t *testing.T) {
 			},
 		},
 		{
-			name:      "local writer skips validation",
+			name:      "writer without chunk limit skips validation",
 			fileLimit: 100,
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return(local.TypeLocal).Once()
+				m.EXPECT().GetOptions().Return(options.Options{NoChunkLimit: true}).Once()
 				return m
 			},
 		},
+		{
+			name:      "writer without chunk limit skips zero chunk size check",
+			fileLimit: math.MaxUint64,
+			setupMock: func(t *testing.T) Writer {
+				t.Helper()
+				m := mocks.NewMockWriter(t)
+				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 0, NoChunkLimit: true}).Once()
+				return m
+			},
+		},
+		// The cases below represent object storage (s3/gcp/azure), which uploads
+		// files as a limited number of chunks and therefore is validated.
 		{
 			name:      "zero chunk size returns error",
 			fileLimit: 1,
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 0}).Once()
 				return m
 			},
@@ -80,7 +90,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: -1}).Once()
 				return m
 			},
@@ -92,7 +101,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 1000}).Once()
 				return m
 			},
@@ -103,7 +111,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				// 10 chunks
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 100}).Once()
 				return m
@@ -115,7 +122,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				// it works as ceil(101/100) = 2
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 100}).Once()
 				return m
@@ -127,7 +133,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				// 9999 chunks
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 100}).Once()
 				return m
@@ -139,7 +144,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: math.MaxInt64}).Once()
 				return m
 			},
@@ -150,7 +154,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				// 10000 chunks
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 100}).Once()
 				return m
@@ -163,7 +166,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 100}).Once()
 				return m
 			},
@@ -175,7 +177,6 @@ func TestValidateFileLimit(t *testing.T) {
 			setupMock: func(t *testing.T) Writer {
 				t.Helper()
 				m := mocks.NewMockWriter(t)
-				m.EXPECT().GetType().Return("s3").Once()
 				m.EXPECT().GetOptions().Return(options.Options{ChunkSize: 1}).Once()
 				return m
 			},


### PR DESCRIPTION
validateFileLimit special-cased local.TypeLocal, which forced the public API package to import a concrete storage backend.

Replace the type check with a NoChunkLimit capability flag on io/storage/options.Options. The flag is set by the writer implementation that owns the knowledge: local and stdout declare it, object storage leaves it false and keeps the 10_000-chunk restriction.

The zero value means "chunked", so every backend's behaviour is unchanged except stdout, which no longer reports the misleading "chunk size must be positive" error for a non-zero file limit.

The Writer interface is untouched, so no mock regeneration is required.