### PR TITLE
BKRS-358 Drain handler errors on wait

### DIFF
--- a/handler_backup.go
+++ b/handler_backup.go
@@ -522,8 +522,10 @@ func (bh *backupHandler) Wait(ctx context.Context) error {
 	// If the err is nil, we can remove the state file.
 	if err == nil && bh.state != nil {
 		// Clean only if err == nil and state is not nil.
-		if err = bh.state.cleanup(ctx); err != nil {
-			bh.logger.Error("failed to cleanup state", slog.Any("error", err))
+		// Failing to remove the state file doesn't make a finished backup
+		// unsuccessful, so log it and keep the job result.
+		if cleanupErr := bh.state.cleanup(ctx); cleanupErr != nil {
+			bh.logger.Error("failed to cleanup state", slog.Any("error", cleanupErr))
 		}
 	}
 

--- a/handler_backup_test.go
+++ b/handler_backup_test.go
@@ -15,10 +15,13 @@
 package backup
 
 import (
+	"bytes"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -101,4 +104,82 @@ func TestBackupHandler_GoroutineLeak_OnSuccess(t *testing.T) {
 	require.LessOrEqual(t, leaked, 0,
 		"goroutine leak detected: started with %d, ended with %d (leaked %d).",
 		initialGoroutines, finalGoroutines, leaked)
+}
+
+// syncBuffer is a concurrency safe io.Writer, so log records emitted by handler
+// goroutines can be inspected without racing the test.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
+}
+
+func TestBackupHandler_Wait_StateCleanupFailureKeepsSuccess(t *testing.T) {
+	t.Parallel()
+
+	testDir := t.TempDir()
+	stateFile := filepath.Join(testDir, "state_file")
+
+	// Setup mocks
+	mockAerospikeClient := mocks.NewMockAerospikeClient(t)
+	mockWriter := mocks.NewMockWriter(t)
+	mockReader := mocks.NewMockStreamingReader(t)
+	mockInfoGetter := mocks.NewMockClusterInfo(t)
+
+	// Configure mock expectations
+	mockWriter.EXPECT().GetType().Return("local").Maybe()
+	mockWriter.EXPECT().GetOptions().Return(options.Options{
+		IsDir: true,
+	}).Maybe()
+	// Removing the state file fails, which must not affect the backup result.
+	mockWriter.EXPECT().Remove(mock.Anything, mock.Anything).
+		Return(errors.New("permission denied")).Once()
+	mockInfoGetter.EXPECT().GetSIndexInfo(mock.Anything, mock.Anything).Return(models.SIndexInfo{}, nil).Maybe()
+
+	logs := &syncBuffer{}
+	logger := slog.New(slog.NewTextHandler(logs, nil))
+
+	cfg := NewDefaultBackupConfig()
+	cfg.Namespace = "test"
+	cfg.StateFile = stateFile
+	cfg.PageSize = 100000
+	cfg.PartitionFilters = []*a.PartitionFilter{
+		NewPartitionFilterByID(1),
+	}
+	cfg.NoRecords = true // Skip actual backup
+	cfg.NoUDFs = true
+	cfg.NoIndexes = true
+
+	handler, err := newBackupHandler(
+		t.Context(),
+		cfg,
+		mockAerospikeClient,
+		logger,
+		mockWriter,
+		mockReader,
+		nil, // scanLimiter
+		mockInfoGetter,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	// Simulate successful backup completion.
+	handler.done <- struct{}{}
+
+	// The job succeeded, so a failing state file cleanup is only logged.
+	require.NoError(t, handler.Wait(t.Context()))
+	require.Contains(t, logs.String(), "failed to cleanup state")
 }

--- a/handler_base.go
+++ b/handler_base.go
@@ -63,6 +63,21 @@ func (h *handlerBase) waitForCompletion(waitCtx context.Context) error {
 	case <-h.done: // Success.
 	}
 
+	// A job failure and a cancellation can become ready at the same moment, and
+	// select picks a ready case at random, so the buffered job error may have
+	// lost the race. It explains the failure better than "context canceled".
+	// Drained before cancel() on purpose: afterwards the channel may hold an
+	// error that our own cancellation provoked.
+	if err != nil {
+		select {
+		case jobErr := <-h.errors:
+			if jobErr != nil {
+				err = jobErr
+			}
+		default:
+		}
+	}
+
 	// Always cancel to stop all goroutines and prevent leaks.
 	h.cancel()
 

--- a/handler_base_test.go
+++ b/handler_base_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errJobFailed stands for a failure reported by the backup/restore job itself.
+var errJobFailed = errors.New("job failed")
+
+// raceAttempts is the number of times a test repeats a case where several
+// select cases are ready at once. A single run would pass by chance, because
+// select picks a ready case at random.
+const raceAttempts = 100
+
+func TestHandlerBase_WaitForCompletion_JobErrorWinsOverWaitCtx(t *testing.T) {
+	t.Parallel()
+
+	for range raceAttempts {
+		h := newHandlerBase(t.Context())
+		h.errors <- errJobFailed
+
+		waitCtx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err := h.waitForCompletion(waitCtx)
+		require.ErrorIs(t, err, errJobFailed)
+	}
+}
+
+func TestHandlerBase_WaitForCompletion_JobErrorWinsOverGlobalCtx(t *testing.T) {
+	t.Parallel()
+
+	for range raceAttempts {
+		ctx, cancel := context.WithCancel(t.Context())
+
+		h := newHandlerBase(ctx)
+		h.errors <- errJobFailed
+
+		cancel()
+
+		err := h.waitForCompletion(t.Context())
+		require.ErrorIs(t, err, errJobFailed)
+	}
+}
+
+func TestHandlerBase_WaitForCompletion_CancelWithoutJobError(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerBase(t.Context())
+
+	waitCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := h.waitForCompletion(waitCtx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestHandlerBase_WaitForCompletion_Success(t *testing.T) {
+	t.Parallel()
+
+	h := newHandlerBase(t.Context())
+	h.done <- struct{}{}
+
+	require.NoError(t, h.waitForCompletion(t.Context()))
+}


### PR DESCRIPTION
- after context cancel check it we have a real error in the errors channel
- fix state cleanup. Because failing to remove the state file doesn't make a finished backup